### PR TITLE
fix(ci): Git tag creation and tag-based GUI release trigger

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -86,3 +86,12 @@ jobs:
         run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create and push Git tag
+        if: steps.check.outputs.publish == 'true'
+        run: |
+          version=${{ steps.check.outputs.version }}
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "v${version}"
+          git push origin "v${version}"

--- a/.github/workflows/release-gui.yml
+++ b/.github/workflows/release-gui.yml
@@ -5,10 +5,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  workflow_run:
-    workflows: ['Release CLI']
-    types:
-      - completed
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 permissions:
@@ -16,7 +15,6 @@ permissions:
 
 jobs:
   check-version:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -24,13 +22,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get version
+        id: version
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            version="${{ github.ref_name }}"
+            version="${version#v}"
+          else
+            version=$(jq -r '.version' cli/package.json)
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Check GitHub Release exists
         id: check-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          version=$(jq -r '.version' cli/package.json)
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          version=${{ steps.version.outputs.version }}
           if gh release view "v${version}" &> /dev/null; then
             echo "Release v${version} already exists, skipping"
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -38,13 +46,6 @@ jobs:
             echo "Release v${version} does not exist, will build and publish"
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Get version
-        id: version
-        if: steps.check-release.outputs.exists != 'true'
-        run: |
-          version=${{ steps.check-release.outputs.version }}
-          echo "version=$version" >> "$GITHUB_OUTPUT"
 
   build-gui:
     needs: check-version


### PR DESCRIPTION
## Changes

- `release-cli.yml`: npm 发布成功后创建并推送 `v${version}` Git tag
- `release-gui.yml`: 触发方式从 `workflow_run` 改为 `push: tags: ['v*']`，版本号优先从 tag 名称提取

## New Release Flow

```
main push → CLI build & npm publish → create Git tag → tag push triggers GUI build → GitHub Release
```

Tag 成为 CLI 和 GUI 发布之间的原子性纽带。npm 发布失败则不会打 tag，GUI 自然不会触发。

Closes #1