### PR TITLE
fix(ci): sync tauri.conf.json version in release-gui workflow

### DIFF
--- a/.github/workflows/release-gui.yml
+++ b/.github/workflows/release-gui.yml
@@ -127,7 +127,8 @@ jobs:
           version=$(jq -r '.version' cli/package.json)
           sed -i.bak "s/^version = \".*\"/version = \"${version}\"/" gui/src-tauri/Cargo.toml
           rm -f gui/src-tauri/Cargo.toml.bak
-          echo "Synced Cargo.toml version to ${version}"
+          jq --arg v "$version" '.version = $v' gui/src-tauri/tauri.conf.json > gui/src-tauri/tauri.conf.tmp && mv gui/src-tauri/tauri.conf.tmp gui/src-tauri/tauri.conf.json
+          echo "Synced Cargo.toml and tauri.conf.json version to ${version}"
 
       - name: Clean old bundle artifacts
         shell: bash


### PR DESCRIPTION
## Summary

Fixes #2 — `release-gui.yml` now syncs the version from `cli/package.json` to both `gui/src-tauri/Cargo.toml` **and** `gui/src-tauri/tauri.conf.json`.

## Change

Added a `jq` command in the "Sync Tauri version from package.json" step to update `tauri.conf.json` alongside `Cargo.toml`. Uses temp file + `mv` pattern to avoid truncation risk.

`jq` is pre-installed on all GitHub Actions runners, no extra setup needed.