### PR TITLE
fix(ci): replace tag trigger with workflow_call for GUI release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -10,9 +10,15 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   release-cli:
     runs-on: ubuntu-24.04
+    outputs:
+      publish: ${{ steps.check.outputs.publish }}
+      version: ${{ steps.check.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -95,3 +101,11 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag "v${version}"
           git push origin "v${version}"
+
+  release-gui:
+    needs: release-cli
+    if: needs.release-cli.outputs.publish == 'true'
+    uses: ./.github/workflows/release-gui.yml
+    with:
+      version: ${{ needs.release-cli.outputs.version }}
+    secrets: inherit

--- a/.github/workflows/release-gui.yml
+++ b/.github/workflows/release-gui.yml
@@ -1,55 +1,27 @@
 name: Release GUI
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.version || github.run_id }}
   cancel-in-progress: true
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (without v prefix, e.g. 2026.10213.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 jobs:
-  check-version:
-    runs-on: ubuntu-24.04
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      release_exists: ${{ steps.check-release.outputs.exists }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get version
-        id: version
-        run: |
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            version="${{ github.ref_name }}"
-            version="${version#v}"
-          else
-            version=$(jq -r '.version' cli/package.json)
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Check GitHub Release exists
-        id: check-release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          version=${{ steps.version.outputs.version }}
-          if gh release view "v${version}" &> /dev/null; then
-            echo "Release v${version} already exists, skipping"
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Release v${version} does not exist, will build and publish"
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
   build-gui:
-    needs: check-version
-    if: needs.check-version.outputs.release_exists != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -121,14 +93,14 @@ jobs:
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Sync Tauri version from package.json
+      - name: Sync Tauri version from CLI
         shell: bash
         run: |
-          version=$(jq -r '.version' cli/package.json)
+          version="${{ inputs.version }}"
           sed -i.bak "s/^version = \".*\"/version = \"${version}\"/" gui/src-tauri/Cargo.toml
           rm -f gui/src-tauri/Cargo.toml.bak
           jq --arg v "$version" '.version = $v' gui/src-tauri/tauri.conf.json > gui/src-tauri/tauri.conf.tmp && mv gui/src-tauri/tauri.conf.tmp gui/src-tauri/tauri.conf.json
-          echo "Synced Cargo.toml and tauri.conf.json version to ${version}"
+          echo "Synced version to ${version}"
 
       - name: Clean old bundle artifacts
         shell: bash
@@ -154,8 +126,7 @@ jobs:
           if-no-files-found: error
 
   publish-release:
-    needs: [check-version, build-gui]
-    if: always() && needs.check-version.outputs.release_exists != 'true' && needs.build-gui.result == 'success'
+    needs: build-gui
     runs-on: ubuntu-24.04
     steps:
       - name: Download all artifacts
@@ -172,8 +143,8 @@ jobs:
       - name: Publish Release
         uses: softprops/action-gh-release@v2.5.0
         with:
-          tag_name: v${{ needs.check-version.outputs.version }}
-          name: v${{ needs.check-version.outputs.version }}
+          tag_name: v${{ inputs.version }}
+          name: v${{ inputs.version }}
           files: |
             artifacts/**/*.dmg
             artifacts/**/*.exe


### PR DESCRIPTION
## Summary

Replace the indirect tag-based trigger chain between `release-cli.yml` and `release-gui.yml` with a direct `workflow_call`, as suggested in #3.

## Changes

- **`release-cli.yml`**: Added job-level outputs (`publish`, `version`), `permissions: contents: write`, and a `release-gui` job that calls the GUI workflow via `workflow_call` with `secrets: inherit`
- **`release-gui.yml`**: Replaced `push: tags: v*` trigger with `workflow_call` + `workflow_dispatch` (both accept explicit `version` input). Removed the redundant `check-version` job entirely

## New Release Flow

1. Push to `main` → `release-cli` job checks version, builds, publishes to npm, creates git tag
2. `release-gui` job is called directly via `workflow_call` with the version
3. GUI builds on 3 platforms and publishes the GitHub Release

Closes #3