### PR TITLE
fix(ci): specify shell for Cargo dependencies hash step in release-gu…

### DIFF
--- a/.github/workflows/release-gui.yml
+++ b/.github/workflows/release-gui.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Get Cargo deps hash (exclude root package version for stable cache key)
         id: cargo-deps-hash
+        shell: bash
         run: |
           # Normalise root package version in Cargo.lock so version bumps don't invalidate cache
           HASH=$(awk '/^name = "memory-sync-gui"$/{print; getline; sub(/version = ".*"/, "version = \"0.0.0\""); print; next} 1' gui/src-tauri/Cargo.lock | sha256sum | cut -d' ' -f1)


### PR DESCRIPTION
…i workflow

Updated the release-gui workflow to explicitly set the shell to bash for the step that calculates the Cargo dependencies hash. This change ensures compatibility and consistency in the execution environment.