### PR TITLE
fix: cursor rule glob formatting

### DIFF
--- a/cli/src/plugins/CursorOutputPlugin.test.ts
+++ b/cli/src/plugins/CursorOutputPlugin.test.ts
@@ -143,10 +143,14 @@ describe('cursor output plugin', () => {
         content: '# TypeScript rule'
       })
       const raw = plugin.buildRuleMdcContentForTest(rule)
-      const parsed = parseMarkdown(raw)
-      const fm = parsed.yamlFrontMatter
-      expect(fm).toBeDefined()
-      expect(Object.keys(fm!).sort()).toEqual(['alwaysApply', 'globs'])
+      const lines = raw.split('\n')
+      const start = lines.indexOf('---')
+      const end = lines.indexOf('---', start + 1)
+      expect(start).toBeGreaterThanOrEqual(0)
+      expect(end).toBeGreaterThan(start)
+      const fmLines = lines.slice(start + 1, end).filter(l => l.trim().length > 0)
+      const keys = fmLines.map(l => l.split(':')[0]!.trim()).sort()
+      expect(keys).toEqual(['alwaysApply', 'globs'])
     })
 
     it('should set alwaysApply to false', () => {
@@ -157,9 +161,10 @@ describe('cursor output plugin', () => {
         content: '# Body'
       })
       const raw = plugin.buildRuleMdcContentForTest(rule)
-      const parsed = parseMarkdown(raw)
-      const fm = parsed.yamlFrontMatter as Record<string, unknown>
-      expect(fm.alwaysApply).toBe(false)
+      const lines = raw.split('\n')
+      const fmLine = lines.find(l => l.trimStart().startsWith('alwaysApply:'))
+      expect(fmLine).toBeDefined()
+      expect(fmLine).toBe('alwaysApply: false')
     })
 
     it('should output globs as comma-separated string, not YAML array', () => {
@@ -170,10 +175,10 @@ describe('cursor output plugin', () => {
         content: '# Body'
       })
       const raw = plugin.buildRuleMdcContentForTest(rule)
-      const parsed = parseMarkdown(raw)
-      const fm = parsed.yamlFrontMatter as Record<string, unknown>
-      expect(typeof fm.globs).toBe('string')
-      expect(fm.globs).toBe('**/*.ts, **/*.tsx')
+      const lines = raw.split('\n')
+      const globsLine = lines.find(l => l.trimStart().startsWith('globs:'))
+      expect(globsLine).toBeDefined()
+      expect(globsLine).toBe('globs: **/*.ts, **/*.tsx')
     })
 
     it('should output single glob as string without trailing comma', () => {
@@ -184,9 +189,10 @@ describe('cursor output plugin', () => {
         content: '# Body'
       })
       const raw = plugin.buildRuleMdcContentForTest(rule)
-      const parsed = parseMarkdown(raw)
-      const fm = parsed.yamlFrontMatter as Record<string, unknown>
-      expect(fm.globs).toBe('**/*.ts')
+      const lines = raw.split('\n')
+      const globsLine = lines.find(l => l.trimStart().startsWith('globs:'))
+      expect(globsLine).toBeDefined()
+      expect(globsLine).toBe('globs: **/*.ts')
     })
 
     it('should output empty string for empty globs', () => {
@@ -225,6 +231,20 @@ describe('cursor output plugin', () => {
       const raw = plugin.buildRuleMdcContentForTest(rule)
       const parsed = parseMarkdown(raw)
       expect(parsed.contentWithoutFrontMatter.trim()).toBe(body)
+    })
+
+    it('should not wrap glob patterns with double quotes in front matter', () => {
+      const rule = createMockRulePrompt({
+        series: 'cursor',
+        ruleName: 'sql',
+        globs: ['**/*.sql'],
+        content: '# SQL rule'
+      })
+      const raw = plugin.buildRuleMdcContentForTest(rule)
+      const lines = raw.split('\n')
+      const globsLine = lines.find(l => l.trimStart().startsWith('globs:'))
+      expect(globsLine).toBeDefined()
+      expect(globsLine).toBe('globs: **/*.sql')
     })
   })
 

--- a/cli/src/plugins/CursorOutputPlugin.ts
+++ b/cli/src/plugins/CursorOutputPlugin.ts
@@ -744,7 +744,20 @@ export class CursorOutputPlugin extends AbstractOutputPlugin {
       alwaysApply: false,
       globs: rule.globs.length > 0 ? rule.globs.join(', ') : ''
     }
-    return buildMarkdownWithFrontMatter(fmData, rule.content)
+    const raw = buildMarkdownWithFrontMatter(fmData, rule.content)
+
+    const lines = raw.split('\n')
+    const transformedLines = lines.map(line => {
+      const match = /^globs:\s*"(.*)"\s*$/.exec(line)
+      if (match == null) return line
+
+      const value = match[1] ?? ''
+      if (value.trim().length === 0) return line
+
+      return `globs: ${value}`
+    })
+
+    return transformedLines.join('\n')
   }
 
   private async writeRuleMdcFile(


### PR DESCRIPTION
## Summary
- Fix Cursor rules globs front matter so patterns like **/*.sql are not wrapped in quotes
- Add regression tests for CursorOutputPlugin rule front matter and glob formatting
- Ensure CLI package builds cleanly with typecheck + lint + bundle

## Test plan
- pnpm -C cli test
- pnpm -C cli build


Made with [Cursor](https://cursor.com)