### PR TITLE
chore: bump version to 2026.10218.11905

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-cli",
   "type": "module",
-  "version": "2026.10218.11636",
+  "version": "2026.10218.11905",
   "description": "TrueNine Memory Synchronization CLI",
   "author": "TrueNine",
   "license": "AGPL-3.0-only",

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-gui",
-  "version": "2026.10218.11636",
+  "version": "2026.10218.11905",
   "private": true,
   "engines": {
     "node": ">=25.2.1",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-sync-gui"
-version = "2026.10218.11636"
+version = "2026.10218.11905"
 description = "Memory Sync desktop GUI application"
 authors = ["TrueNine"]
 edition = "2021"

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "version": "2026.10218.11636",
+  "version": "2026.10218.11905",
   "productName": "Memory Sync",
   "identifier": "org.truenine.memory-sync",
   "build": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync",
-  "version": "2026.10218.11636",
+  "version": "2026.10218.11905",
   "description": "Cross-AI-tool prompt synchronisation toolkit (CLI + Tauri desktop GUI) — one ruleset, multi-target adaptation. Monorepo powered by pnpm + Turbo.",
   "license": "AGPL-3.0-only",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bump project version to 2026.10218.11905 in package metadata

## Test plan
- pnpm -C cli test
- pnpm -C cli build


Made with [Cursor](https://cursor.com)