### PR TITLE
feat: implement project.jsonc rules filtering with seriName support

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -52,6 +52,7 @@
     "@clack/prompts": "catalog:",
     "fast-glob": "catalog:",
     "fs-extra": "catalog:",
+    "jsonc-parser": "catalog:",
     "picocolors": "catalog:",
     "picomatch": "catalog:"
   },

--- a/cli/src/plugins/ClaudeCodeCLIOutputPlugin.projectConfig.test.ts
+++ b/cli/src/plugins/ClaudeCodeCLIOutputPlugin.projectConfig.test.ts
@@ -1,0 +1,238 @@
+import type {OutputPluginContext} from '@/types'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {collectFileNames, createMockProject, createMockRulePrompt} from './__testUtils__'
+import {ClaudeCodeCLIOutputPlugin} from './ClaudeCodeCLIOutputPlugin'
+
+class TestableClaudeCodeCLIOutputPlugin extends ClaudeCodeCLIOutputPlugin {
+  private mockHomeDir: string | null = null
+
+  public setMockHomeDir(dir: string | null): void {
+    this.mockHomeDir = dir
+  }
+
+  protected override getHomeDir(): string {
+    if (this.mockHomeDir != null) return this.mockHomeDir
+    return super.getHomeDir()
+  }
+}
+
+function createMockContext(
+  tempDir: string,
+  rules: unknown[],
+  projects: unknown[]
+): OutputPluginContext {
+  return {
+    collectedInputContext: {
+      workspace: {
+        projects: projects as never,
+        directory: {
+          pathKind: 1,
+          path: tempDir,
+          basePath: tempDir,
+          getDirectoryName: () => 'workspace',
+          getAbsolutePath: () => tempDir
+        }
+      },
+      ideConfigFiles: [],
+      rules: rules as never,
+      fastCommands: [],
+      skills: [],
+      globalMemory: void 0,
+      aiAgentIgnoreConfigFiles: [],
+      subAgents: []
+    },
+    logger: {
+      debug: vi.fn(),
+      trace: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    } as never,
+    fs,
+    path,
+    glob: vi.fn() as never
+  }
+}
+
+describe('claudeCodeCLIOutputPlugin - projectConfig filtering', () => {
+  let tempDir: string,
+    plugin: TestableClaudeCodeCLIOutputPlugin
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-proj-config-test-'))
+    plugin = new TestableClaudeCodeCLIOutputPlugin()
+    plugin.setMockHomeDir(tempDir)
+  })
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tempDir, {recursive: true, force: true})
+    }
+    catch {}
+  })
+
+  describe('registerProjectOutputFiles', () => {
+    it('should include all project rules when no projectConfig', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [createMockProject('proj1', tempDir, 'proj1')]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.md')
+      expect(fileNames).toContain('rule-test-rule2.md')
+    })
+
+    it('should filter rules by include in projectConfig', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.md')
+      expect(fileNames).not.toContain('rule-test-rule2.md')
+    })
+
+    it('should filter rules by exclude in projectConfig', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {exclude: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).not.toContain('rule-test-rule1.md')
+      expect(fileNames).toContain('rule-test-rule2.md')
+    })
+
+    it('should expand include with subSeries', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'uniapp3', 'project'),
+        createMockRulePrompt('test', 'rule3', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {
+          rules: {
+            include: ['uniapp'],
+            subSeries: {uniapp: ['uniapp3']}
+          }
+        })
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.md')
+      expect(fileNames).toContain('rule-test-rule2.md')
+      expect(fileNames).not.toContain('rule-test-rule3.md')
+    })
+
+    it('should include rules without seriName regardless of include filter', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', void 0, 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.md')
+      expect(fileNames).not.toContain('rule-test-rule2.md')
+    })
+
+    it('should filter independently for each project', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}}),
+        createMockProject('proj2', tempDir, 'proj2', {rules: {include: ['vue']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = results.map(r => ({
+        path: r.path,
+        fileName: r.path.split(/[/\\]/).pop()
+      }))
+
+      expect(fileNames.some(f => f.path.includes('proj1') && f.fileName === 'rule-test-rule1.md')).toBe(true)
+      expect(fileNames.some(f => f.path.includes('proj1') && f.fileName === 'rule-test-rule2.md')).toBe(false)
+      expect(fileNames.some(f => f.path.includes('proj2') && f.fileName === 'rule-test-rule2.md')).toBe(true)
+      expect(fileNames.some(f => f.path.includes('proj2') && f.fileName === 'rule-test-rule1.md')).toBe(false)
+    })
+
+    it('should return empty when include matches nothing', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['react']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const ruleFiles = results.filter(r => r.path.includes('rule-'))
+
+      expect(ruleFiles).toHaveLength(0)
+    })
+  })
+
+  describe('registerProjectOutputDirs', () => {
+    it('should not register rules dir when all rules filtered out', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['react']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputDirs(ctx)
+      const rulesDirs = results.filter(r => r.path.includes('rules'))
+
+      expect(rulesDirs).toHaveLength(0)
+    })
+
+    it('should register rules dir when rules match filter', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputDirs(ctx)
+      const rulesDirs = results.filter(r => r.path.includes('rules'))
+
+      expect(rulesDirs.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/cli/src/plugins/ClaudeCodeCLIOutputPlugin.ts
+++ b/cli/src/plugins/ClaudeCodeCLIOutputPlugin.ts
@@ -1,6 +1,7 @@
 import type {OutputPluginContext, OutputWriteContext, RulePrompt, WriteResults} from '@/types'
 import type {RelativePath} from '@/types/FileSystemTypes'
 import * as path from 'node:path'
+import {filterRulesByProjectConfig} from '@/utils/ruleFilter'
 import {BaseCLIOutputPlugin} from './BaseCLIOutputPlugin'
 
 const PROJECT_MEMORY_FILE = 'CLAUDE.md'
@@ -47,10 +48,15 @@ export class ClaudeCodeCLIOutputPlugin extends BaseCLIOutputPlugin {
 
   override async registerProjectOutputDirs(ctx: OutputPluginContext): Promise<RelativePath[]> {
     const results = await super.registerProjectOutputDirs(ctx)
-    const projectRules = ctx.collectedInputContext.rules?.filter(r => this.normalizeRuleScope(r) === 'project')
-    if (projectRules == null || projectRules.length === 0) return results
+    const {rules} = ctx.collectedInputContext
+    if (rules == null || rules.length === 0) return results
     for (const project of ctx.collectedInputContext.workspace.projects) {
       if (project.dirFromWorkspacePath == null) continue
+      const projectRules = filterRulesByProjectConfig(
+        rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+        project.projectConfig
+      )
+      if (projectRules.length === 0) continue
       const dirPath = path.join(project.dirFromWorkspacePath.path, this.globalConfigDir, RULES_SUBDIR)
       results.push(this.createRelativePath(dirPath, project.dirFromWorkspacePath.basePath, () => RULES_SUBDIR))
     }
@@ -59,10 +65,14 @@ export class ClaudeCodeCLIOutputPlugin extends BaseCLIOutputPlugin {
 
   override async registerProjectOutputFiles(ctx: OutputPluginContext): Promise<RelativePath[]> {
     const results = await super.registerProjectOutputFiles(ctx)
-    const projectRules = ctx.collectedInputContext.rules?.filter(r => this.normalizeRuleScope(r) === 'project')
-    if (projectRules == null || projectRules.length === 0) return results
+    const {rules} = ctx.collectedInputContext
+    if (rules == null || rules.length === 0) return results
     for (const project of ctx.collectedInputContext.workspace.projects) {
       if (project.dirFromWorkspacePath == null) continue
+      const projectRules = filterRulesByProjectConfig(
+        rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+        project.projectConfig
+      )
       for (const rule of projectRules) {
         const filePath = path.join(project.dirFromWorkspacePath.path, this.globalConfigDir, RULES_SUBDIR, this.buildRuleFileName(rule))
         results.push(this.createRelativePath(filePath, project.dirFromWorkspacePath.basePath, () => RULES_SUBDIR))
@@ -88,11 +98,16 @@ export class ClaudeCodeCLIOutputPlugin extends BaseCLIOutputPlugin {
 
   override async writeProjectOutputs(ctx: OutputWriteContext): Promise<WriteResults> {
     const results = await super.writeProjectOutputs(ctx)
-    const projectRules = ctx.collectedInputContext.rules?.filter(r => this.normalizeRuleScope(r) === 'project')
-    if (projectRules == null || projectRules.length === 0) return results
+    const {rules} = ctx.collectedInputContext
+    if (rules == null || rules.length === 0) return results
     const ruleResults = []
     for (const project of ctx.collectedInputContext.workspace.projects) {
       if (project.dirFromWorkspacePath == null) continue
+      const projectRules = filterRulesByProjectConfig(
+        rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+        project.projectConfig
+      )
+      if (projectRules.length === 0) continue
       const rulesDir = path.join(project.dirFromWorkspacePath.basePath, project.dirFromWorkspacePath.path, this.globalConfigDir, RULES_SUBDIR)
       for (const rule of projectRules) ruleResults.push(await this.writeFile(ctx, path.join(rulesDir, this.buildRuleFileName(rule)), this.buildRuleContent(rule), 'rule'))
     }

--- a/cli/src/plugins/CursorOutputPlugin.projectConfig.test.ts
+++ b/cli/src/plugins/CursorOutputPlugin.projectConfig.test.ts
@@ -1,0 +1,238 @@
+import type {OutputPluginContext} from '@/types'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {collectFileNames, createMockProject, createMockRulePrompt} from './__testUtils__'
+import {CursorOutputPlugin} from './CursorOutputPlugin'
+
+class TestableCursorOutputPlugin extends CursorOutputPlugin {
+  private mockHomeDir: string | null = null
+
+  public setMockHomeDir(dir: string | null): void {
+    this.mockHomeDir = dir
+  }
+
+  protected override getHomeDir(): string {
+    if (this.mockHomeDir != null) return this.mockHomeDir
+    return super.getHomeDir()
+  }
+}
+
+function createMockContext(
+  tempDir: string,
+  rules: unknown[],
+  projects: unknown[]
+): OutputPluginContext {
+  return {
+    collectedInputContext: {
+      workspace: {
+        projects: projects as never,
+        directory: {
+          pathKind: 1,
+          path: tempDir,
+          basePath: tempDir,
+          getDirectoryName: () => 'workspace',
+          getAbsolutePath: () => tempDir
+        }
+      },
+      ideConfigFiles: [],
+      rules: rules as never,
+      fastCommands: [],
+      skills: [],
+      globalMemory: void 0,
+      aiAgentIgnoreConfigFiles: []
+    },
+    logger: {
+      debug: vi.fn(),
+      trace: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    } as never,
+    fs,
+    path,
+    glob: vi.fn() as never
+  }
+}
+
+describe('cursorOutputPlugin - projectConfig filtering', () => {
+  let tempDir: string,
+    plugin: TestableCursorOutputPlugin
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-proj-config-test-'))
+    plugin = new TestableCursorOutputPlugin()
+    plugin.setMockHomeDir(tempDir)
+  })
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tempDir, {recursive: true, force: true})
+    }
+    catch {}
+  })
+
+  describe('registerProjectOutputFiles', () => {
+    it('should include all project rules when no projectConfig', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [createMockProject('proj1', tempDir, 'proj1')]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.mdc')
+      expect(fileNames).toContain('rule-test-rule2.mdc')
+    })
+
+    it('should filter rules by include in projectConfig', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.mdc')
+      expect(fileNames).not.toContain('rule-test-rule2.mdc')
+    })
+
+    it('should filter rules by exclude in projectConfig', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {exclude: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).not.toContain('rule-test-rule1.mdc')
+      expect(fileNames).toContain('rule-test-rule2.mdc')
+    })
+
+    it('should expand include with subSeries', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'uniapp3', 'project'),
+        createMockRulePrompt('test', 'rule3', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {
+          rules: {
+            include: ['uniapp'],
+            subSeries: {uniapp: ['uniapp3']}
+          }
+        })
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.mdc')
+      expect(fileNames).toContain('rule-test-rule2.mdc')
+      expect(fileNames).not.toContain('rule-test-rule3.mdc')
+    })
+
+    it('should include rules without seriName regardless of include filter', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', void 0, 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.mdc')
+      expect(fileNames).not.toContain('rule-test-rule2.mdc')
+    })
+
+    it('should filter independently for each project', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}}),
+        createMockProject('proj2', tempDir, 'proj2', {rules: {include: ['vue']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = results.map(r => ({
+        path: r.path,
+        fileName: r.path.split(/[/\\]/).pop()
+      }))
+
+      expect(fileNames.some(f => f.path.includes('proj1') && f.fileName === 'rule-test-rule1.mdc')).toBe(true) // proj1 should have rule1
+      expect(fileNames.some(f => f.path.includes('proj1') && f.fileName === 'rule-test-rule2.mdc')).toBe(false)
+
+      expect(fileNames.some(f => f.path.includes('proj2') && f.fileName === 'rule-test-rule2.mdc')).toBe(true) // proj2 should have rule2
+      expect(fileNames.some(f => f.path.includes('proj2') && f.fileName === 'rule-test-rule1.mdc')).toBe(false)
+    })
+
+    it('should return empty when include matches nothing', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['react']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const ruleFiles = results.filter(r => r.path.includes('rule-'))
+
+      expect(ruleFiles).toHaveLength(0)
+    })
+  })
+
+  describe('registerProjectOutputDirs', () => {
+    it('should register rules dir when project rules exist (directory registration is pre-filter)', async () => {
+      const rules = [ // The actual filtering happens in registerProjectOutputFiles and writeProjectOutputs // Note: registerProjectOutputDirs registers directories if any project rules exist
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['react']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputDirs(ctx)
+      const rulesDirs = results.filter(r => r.path.includes('rules'))
+
+      expect(rulesDirs.length).toBeGreaterThan(0) // Directory is registered because rules exist (even if filtered out later)
+    })
+
+    it('should register rules dir when rules match filter', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputDirs(ctx)
+      const rulesDirs = results.filter(r => r.path.includes('rules'))
+
+      expect(rulesDirs.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/cli/src/plugins/CursorOutputPlugin.ts
+++ b/cli/src/plugins/CursorOutputPlugin.ts
@@ -14,6 +14,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import {buildMarkdownWithFrontMatter} from '@truenine/md-compiler/markdown'
 import {FilePathKind} from '@/types'
+import {filterRulesByProjectConfig} from '@/utils/ruleFilter'
 import {AbstractOutputPlugin} from './AbstractOutputPlugin'
 
 const GLOBAL_CONFIG_DIR = '.cursor'
@@ -241,10 +242,8 @@ export class CursorOutputPlugin extends AbstractOutputPlugin {
   async registerProjectOutputFiles(ctx: OutputPluginContext): Promise<RelativePath[]> {
     const results: RelativePath[] = []
     const {workspace, globalMemory, rules} = ctx.collectedInputContext
-    const projectRules = rules?.filter(r => this.normalizeRuleScope(r) === 'project')
-    const hasProjectRules = projectRules != null && projectRules.length > 0
 
-    if (globalMemory == null && !hasProjectRules) return results
+    if (globalMemory == null && rules == null) return results
 
     if (globalMemory != null) {
       for (const project of workspace.projects) {
@@ -254,10 +253,14 @@ export class CursorOutputPlugin extends AbstractOutputPlugin {
       }
     }
 
-    if (hasProjectRules) {
+    if (rules != null && rules.length > 0) {
       for (const project of workspace.projects) {
         const projectDir = project.dirFromWorkspacePath
         if (projectDir == null) continue
+        const projectRules = filterRulesByProjectConfig(
+          rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+          project.projectConfig
+        )
         for (const rule of projectRules) {
           const fileName = this.buildRuleFileName(rule)
           results.push(this.createProjectRuleFileRelativePath(projectDir, fileName))
@@ -337,11 +340,15 @@ export class CursorOutputPlugin extends AbstractOutputPlugin {
       }
     }
 
-    const projectRules = rules?.filter(r => this.normalizeRuleScope(r) === 'project')
-    if (projectRules != null && projectRules.length > 0) {
+    if (rules != null && rules.length > 0) {
       for (const project of workspace.projects) {
         const projectDir = project.dirFromWorkspacePath
         if (projectDir == null) continue
+        const projectRules = filterRulesByProjectConfig(
+          rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+          project.projectConfig
+        )
+        if (projectRules.length === 0) continue
         const rulesDir = path.join(projectDir.basePath, projectDir.path, GLOBAL_CONFIG_DIR, RULES_SUBDIR)
         for (const rule of projectRules) {
           const result = await this.writeRuleMdcFile(ctx, rulesDir, rule, projectDir.basePath)

--- a/cli/src/plugins/KiroCLIOutputPlugin.projectConfig.test.ts
+++ b/cli/src/plugins/KiroCLIOutputPlugin.projectConfig.test.ts
@@ -1,0 +1,223 @@
+import type {OutputPluginContext} from '@/types'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {collectFileNames, createMockProject, createMockRulePrompt} from './__testUtils__'
+import {KiroCLIOutputPlugin} from './KiroCLIOutputPlugin'
+
+class TestableKiroCLIOutputPlugin extends KiroCLIOutputPlugin {
+  private mockHomeDir: string | null = null
+
+  public setMockHomeDir(dir: string | null): void {
+    this.mockHomeDir = dir
+  }
+
+  protected override getHomeDir(): string {
+    if (this.mockHomeDir != null) return this.mockHomeDir
+    return super.getHomeDir()
+  }
+}
+
+function createMockContext(
+  tempDir: string,
+  rules: unknown[],
+  projects: unknown[]
+): OutputPluginContext {
+  return {
+    collectedInputContext: {
+      workspace: {
+        projects: projects as never,
+        directory: {
+          pathKind: 1,
+          path: tempDir,
+          basePath: tempDir,
+          getDirectoryName: () => 'workspace',
+          getAbsolutePath: () => tempDir
+        }
+      },
+      ideConfigFiles: [],
+      rules: rules as never,
+      fastCommands: [],
+      skills: [],
+      globalMemory: void 0,
+      aiAgentIgnoreConfigFiles: []
+    },
+    logger: {
+      debug: vi.fn(),
+      trace: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    } as never,
+    fs,
+    path,
+    glob: vi.fn() as never
+  }
+}
+
+describe('kiroCLIOutputPlugin - projectConfig filtering', () => {
+  let tempDir: string,
+    plugin: TestableKiroCLIOutputPlugin
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-proj-config-test-'))
+    plugin = new TestableKiroCLIOutputPlugin()
+    plugin.setMockHomeDir(tempDir)
+  })
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tempDir, {recursive: true, force: true})
+    }
+    catch {}
+  })
+
+  describe('registerProjectOutputFiles', () => {
+    it('should include all project rules when no projectConfig', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [createMockProject('proj1', tempDir, 'proj1')]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.md')
+      expect(fileNames).toContain('rule-test-rule2.md')
+    })
+
+    it('should filter rules by include in projectConfig', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.md')
+      expect(fileNames).not.toContain('rule-test-rule2.md')
+    })
+
+    it('should filter rules by exclude in projectConfig', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {exclude: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).not.toContain('rule-test-rule1.md')
+      expect(fileNames).toContain('rule-test-rule2.md')
+    })
+
+    it('should expand include with subSeries', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'uniapp3', 'project'),
+        createMockRulePrompt('test', 'rule3', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {
+          rules: {
+            include: ['uniapp'],
+            subSeries: {uniapp: ['uniapp3']}
+          }
+        })
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.md')
+      expect(fileNames).toContain('rule-test-rule2.md')
+      expect(fileNames).not.toContain('rule-test-rule3.md')
+    })
+
+    it('should include rules without seriName regardless of include filter', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', void 0, 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.md')
+      expect(fileNames).not.toContain('rule-test-rule2.md')
+    })
+
+    it('should filter independently for each project', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}}),
+        createMockProject('proj2', tempDir, 'proj2', {rules: {include: ['vue']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = results.map(r => ({
+        path: r.path,
+        fileName: r.path.split(/[/\\]/).pop()
+      }))
+
+      expect(fileNames.some(f => f.path.includes('proj1') && f.fileName === 'rule-test-rule1.md')).toBe(true)
+      expect(fileNames.some(f => f.path.includes('proj1') && f.fileName === 'rule-test-rule2.md')).toBe(false)
+      expect(fileNames.some(f => f.path.includes('proj2') && f.fileName === 'rule-test-rule2.md')).toBe(true)
+      expect(fileNames.some(f => f.path.includes('proj2') && f.fileName === 'rule-test-rule1.md')).toBe(false)
+    })
+
+    it('should return empty when include matches nothing', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['react']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const ruleFiles = results.filter(r => r.path.includes('rule-'))
+
+      expect(ruleFiles).toHaveLength(0)
+    })
+  })
+
+  describe('writeProjectOutputs', () => {
+    it('should write only filtered rules to each project', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.writeProjectOutputs(ctx)
+
+      expect(results.files.some(f => f.path.path.includes('rule-test-rule1.md'))).toBe(true)
+      expect(results.files.some(f => f.path.path.includes('rule-test-rule2.md'))).toBe(false)
+    })
+  })
+})

--- a/cli/src/plugins/KiroCLIOutputPlugin.ts
+++ b/cli/src/plugins/KiroCLIOutputPlugin.ts
@@ -12,6 +12,7 @@ import type {
   WriteResults
 } from '@/types'
 import type {RelativePath} from '@/types/FileSystemTypes'
+import {filterRulesByProjectConfig} from '@/utils/ruleFilter'
 import {AbstractOutputPlugin} from './AbstractOutputPlugin'
 import {KiroPowersRegistryWriter} from './registry/KiroPowersRegistryWriter'
 
@@ -95,8 +96,11 @@ export class KiroCLIOutputPlugin extends AbstractOutputPlugin {
         }
       }
 
-      const projectRules = rules?.filter(r => r.scope === 'project')
-      if (projectRules != null && projectRules.length > 0) {
+      if (rules != null && rules.length > 0) {
+        const projectRules = filterRulesByProjectConfig(
+          rules.filter(r => r.scope === 'project'),
+          project.projectConfig
+        )
         for (const rule of projectRules) {
           const fileName = this.buildRuleSteeringFileName(rule)
           results.push(this.createRelativePath(
@@ -223,8 +227,11 @@ export class KiroCLIOutputPlugin extends AbstractOutputPlugin {
         for (const child of project.childMemoryPrompts) fileResults.push(await this.writeSteeringFile(ctx, project, child))
       }
 
-      const projectRules = rules?.filter(r => r.scope === 'project')
-      if (projectRules != null && projectRules.length > 0) {
+      if (rules != null && rules.length > 0) {
+        const projectRules = filterRulesByProjectConfig(
+          rules.filter(r => r.scope === 'project'),
+          project.projectConfig
+        )
         for (const rule of projectRules) fileResults.push(await this.writeRuleSteeringFile(ctx, project, rule))
       }
     }

--- a/cli/src/plugins/RuleInputPlugin.test.ts
+++ b/cli/src/plugins/RuleInputPlugin.test.ts
@@ -1,9 +1,11 @@
-import type {RulePrompt} from '@/types'
+import type {ILogger} from '@/log'
+import type {InputPluginContext, RulePrompt} from '@/types'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {validateRuleMetadata} from '@/types'
+import {RuleInputPlugin} from './RuleInputPlugin'
 
 describe('validateRuleMetadata', () => {
   it('should pass with valid metadata', () => {
@@ -110,6 +112,29 @@ describe('validateRuleMetadata', () => {
     expect(result.valid).toBe(false)
     expect(result.errors.every(e => e.includes('test/file.mdx'))).toBe(true)
   })
+
+  it('should pass when seriName is a valid string', () => {
+    const result = validateRuleMetadata({globs: ['**/*.ts'], description: 'desc', scope: 'project', seriName: 'uniapp3'})
+    expect(result.valid).toBe(true)
+    expect(result.errors).toHaveLength(0)
+  })
+
+  it('should pass when seriName is absent', () => {
+    const result = validateRuleMetadata({globs: ['**/*.ts'], description: 'desc', scope: 'project'})
+    expect(result.valid).toBe(true)
+  })
+
+  it('should fail when seriName is not a string', () => {
+    const result = validateRuleMetadata({globs: ['**/*.ts'], description: 'desc', scope: 'project', seriName: 42})
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('seriName'))).toBe(true)
+  })
+
+  it('should fail when seriName is an object', () => {
+    const result = validateRuleMetadata({globs: ['**/*.ts'], description: 'desc', seriName: {}})
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('seriName'))).toBe(true)
+  })
 })
 
 describe('ruleInputPlugin - file structure', () => {
@@ -210,6 +235,70 @@ describe('rule scope defaults', () => {
   it('should use explicit global scope', () => {
     const scope: string = 'global'
     expect(scope).toBe('global')
+  })
+})
+
+describe('ruleInputPlugin - seriName propagation', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rule-seri-'))
+    fs.mkdirSync(path.join(tempDir, 'shadow', 'rules', 'my-series'), {recursive: true})
+  })
+
+  afterEach(() => fs.rmSync(tempDir, {recursive: true, force: true}))
+
+  function createCtx(): InputPluginContext {
+    return {
+      logger: {debug: vi.fn(), trace: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()} as unknown as ILogger,
+      fs,
+      path,
+      glob: vi.fn() as never,
+      userConfigOptions: {
+        workspaceDir: tempDir,
+        shadowSourceProject: {
+          name: 'shadow',
+          skill: {src: 'src/skills', dist: 'dist/skills'},
+          fastCommand: {src: 'src/commands', dist: 'dist/commands'},
+          subAgent: {src: 'src/agents', dist: 'dist/agents'},
+          rule: {src: 'src/rules', dist: 'rules'},
+          globalMemory: {src: 'app/global.cn.mdx', dist: 'dist/global.mdx'},
+          workspaceMemory: {src: 'app/workspace.cn.mdx', dist: 'dist/app/workspace.mdx'},
+          project: {src: 'app', dist: 'dist/app'}
+        },
+        fastCommandSeriesOptions: {},
+        plugins: [],
+        logLevel: 'info'
+      } as never,
+      dependencyContext: {},
+      globalScope: {
+        profile: {name: 'test', username: 'test', gender: 'male', birthday: '2000-01-01'},
+        tool: {name: 'test'},
+        env: {},
+        os: {platform: 'linux', arch: 'x64', homedir: '/home/test'},
+        Md: vi.fn()
+      } as never
+    }
+  }
+
+  it('should propagate seriName from YAML front matter to RulePrompt', async () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'shadow', 'rules', 'my-series', 'my-rule.mdx'),
+      ['---', 'globs: ["**/*.ts"]', 'description: Test rule', 'scope: project', 'seriName: uniapp3', 'namingCase: kebab-case', '---', '', '# Rule'].join('\n')
+    )
+    const result = await new RuleInputPlugin().collect(createCtx())
+    const rule = result.rules?.[0]
+    expect(rule?.seriName).toBe('uniapp3')
+  })
+
+  it('should leave seriName undefined when not in front matter', async () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'shadow', 'rules', 'my-series', 'no-seri.mdx'),
+      ['---', 'globs: ["**/*.ts"]', 'description: No seri', 'scope: project', 'namingCase: kebab-case', '---', '', '# Rule'].join('\n')
+    )
+    const result = await new RuleInputPlugin().collect(createCtx())
+    const rule = result.rules?.[0]
+    expect(rule?.seriName).toBeUndefined()
   })
 })
 

--- a/cli/src/plugins/RuleInputPlugin.ts
+++ b/cli/src/plugins/RuleInputPlugin.ts
@@ -52,6 +52,7 @@ export class RuleInputPlugin extends BaseDirectoryInputPlugin<RulePrompt, RuleYA
 
     const globs: readonly string[] = yamlFrontMatter?.globs ?? []
     const scope: RuleScope = yamlFrontMatter?.scope ?? 'project'
+    const seriName = yamlFrontMatter?.seriName
 
     return {
       type: PromptKind.Rule,
@@ -73,6 +74,7 @@ export class RuleInputPlugin extends BaseDirectoryInputPlugin<RulePrompt, RuleYA
       ruleName,
       globs,
       scope,
+      ...seriName != null && {seriName},
       rawMdxContent: rawContent
     }
   }

--- a/cli/src/plugins/ShadowProjectInputPlugin.test.ts
+++ b/cli/src/plugins/ShadowProjectInputPlugin.test.ts
@@ -1,0 +1,165 @@
+import type {ILogger} from '@/log'
+import type {InputPluginContext, PluginOptions} from '@/types'
+import * as path from 'node:path'
+import * as fc from 'fast-check'
+import {describe, expect, it, vi} from 'vitest'
+import {ShadowProjectInputPlugin} from './ShadowProjectInputPlugin'
+
+const W = '/workspace'
+const SHADOW = 'shadow'
+const SHADOW_DIR = path.join(W, SHADOW)
+const DIST_APP = path.join(SHADOW_DIR, 'dist/app')
+const SRC_APP = path.join(SHADOW_DIR, 'app')
+
+function mockLogger(): ILogger {
+  return {debug: vi.fn(), trace: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()} as unknown as ILogger
+}
+
+function mockOptions(): Required<PluginOptions> {
+  return {
+    workspaceDir: W,
+    shadowSourceProject: {
+      name: SHADOW,
+      skill: {src: 'src/skills', dist: 'dist/skills'},
+      fastCommand: {src: 'src/commands', dist: 'dist/commands'},
+      subAgent: {src: 'src/agents', dist: 'dist/agents'},
+      rule: {src: 'src/rules', dist: 'dist/rules'},
+      globalMemory: {src: 'app/global.cn.mdx', dist: 'dist/global.mdx'},
+      workspaceMemory: {src: 'app/workspace.cn.mdx', dist: 'dist/app/workspace.mdx'},
+      project: {src: 'app', dist: 'dist/app'}
+    },
+    fastCommandSeriesOptions: {},
+    plugins: [],
+    logLevel: 'info'
+  } as never
+}
+
+function projectJsoncPath(name: string): string {
+  return path.join(SRC_APP, name, 'project.jsonc')
+}
+
+function makeDirEntry(name: string) {
+  return {name, isDirectory: () => true, isFile: () => false}
+}
+
+function createCtx(mockFs: unknown, logger = mockLogger()): InputPluginContext {
+  return {
+    logger,
+    fs: mockFs as typeof import('node:fs'),
+    path,
+    glob: vi.fn() as never,
+    userConfigOptions: mockOptions(),
+    dependencyContext: {},
+    globalScope: void 0 as never
+  }
+}
+
+function buildMockFs(projectName: string, jsoncContent: string | null) {
+  const jsoncPath = projectJsoncPath(projectName)
+  return {
+    existsSync: vi.fn((p: string) => {
+      if (p === DIST_APP) return true
+      if (p === jsoncPath) return jsoncContent != null
+      return false
+    }),
+    statSync: vi.fn(() => ({isDirectory: () => true})),
+    readdirSync: vi.fn((p: string) => p === DIST_APP ? [makeDirEntry(projectName)] : []),
+    readFileSync: vi.fn((p: string) => {
+      if (p === jsoncPath && jsoncContent != null) return jsoncContent
+      throw new Error(`unexpected readFileSync: ${p}`)
+    })
+  }
+}
+
+describe('shadowProjectInputPlugin - project.jsonc loading', () => {
+  it('attaches projectConfig when project.jsonc exists', () => {
+    const config = {rules: {include: ['uniapp3'], exclude: ['backend']}}
+    const mockFs = buildMockFs('my-project', JSON.stringify(config))
+    const result = new ShadowProjectInputPlugin().collect(createCtx(mockFs))
+    const project = result.workspace?.projects.find(p => p.name === 'my-project')
+    expect(project?.projectConfig).toEqual(config)
+  })
+
+  it('leaves projectConfig undefined when project.jsonc is absent', () => {
+    const mockFs = buildMockFs('my-project', null)
+    const result = new ShadowProjectInputPlugin().collect(createCtx(mockFs))
+    const project = result.workspace?.projects.find(p => p.name === 'my-project')
+    expect(project?.projectConfig).toBeUndefined()
+  })
+
+  it('parses JSONC with comments correctly', () => {
+    const jsonc = '{\n  // enable uniapp rules\n  "rules": {"include": ["uniapp3"]}\n}'
+    const mockFs = buildMockFs('proj', jsonc)
+    const result = new ShadowProjectInputPlugin().collect(createCtx(mockFs))
+    expect(result.workspace?.projects[0]?.projectConfig?.rules?.include).toEqual(['uniapp3'])
+  })
+
+  it('leaves projectConfig undefined and warns on malformed JSONC', () => {
+    const logger = mockLogger()
+    const mockFs = buildMockFs('proj', '{invalid json{{')
+    const result = new ShadowProjectInputPlugin().collect(createCtx(mockFs, logger))
+    expect(result.workspace?.projects[0]?.projectConfig).toBeUndefined()
+  })
+
+  it('attaches mcp.names from project.jsonc', () => {
+    const config = {mcp: {names: ['context7', 'deepwiki']}}
+    const mockFs = buildMockFs('proj', JSON.stringify(config))
+    const result = new ShadowProjectInputPlugin().collect(createCtx(mockFs))
+    expect(result.workspace?.projects[0]?.projectConfig?.mcp?.names).toEqual(['context7', 'deepwiki'])
+  })
+
+  it('attaches rules.subSeries from project.jsonc', () => {
+    const config = {rules: {subSeries: {backend: ['api-rules'], frontend: ['vue-rules']}}}
+    const mockFs = buildMockFs('proj', JSON.stringify(config))
+    const result = new ShadowProjectInputPlugin().collect(createCtx(mockFs))
+    expect(result.workspace?.projects[0]?.projectConfig?.rules?.subSeries).toEqual(config.rules.subSeries)
+  })
+
+  it('does not affect other project fields when project.jsonc is absent', () => {
+    const mockFs = buildMockFs('proj', null)
+    const result = new ShadowProjectInputPlugin().collect(createCtx(mockFs))
+    const p = result.workspace?.projects[0]
+    expect(p?.name).toBe('proj')
+    expect(p?.dirFromWorkspacePath).toBeDefined()
+    expect(p?.projectConfig).toBeUndefined()
+  })
+
+  it('handles empty project.jsonc object', () => {
+    const mockFs = buildMockFs('proj', '{}')
+    const result = new ShadowProjectInputPlugin().collect(createCtx(mockFs))
+    expect(result.workspace?.projects[0]?.projectConfig).toEqual({})
+  })
+})
+
+describe('shadowProjectInputPlugin - project.jsonc property tests', () => {
+  const projectNameGen = fc.stringMatching(/^[a-z][a-z0-9-]{0,19}$/)
+  const stringArrayGen = fc.array(fc.string({minLength: 1, maxLength: 20}), {maxLength: 5})
+
+  it('projectConfig is always attached when project.jsonc exists with valid JSON', () => {
+    fc.assert(fc.property(projectNameGen, stringArrayGen, (name, include) => {
+      const config = {rules: {include}}
+      const mockFs = buildMockFs(name, JSON.stringify(config))
+      const result = new ShadowProjectInputPlugin().collect(createCtx(mockFs))
+      const project = result.workspace?.projects.find(p => p.name === name)
+      expect(project?.projectConfig?.rules?.include).toEqual(include)
+    }))
+  })
+
+  it('projectConfig is always undefined when project.jsonc is absent', () => {
+    fc.assert(fc.property(projectNameGen, name => {
+      const mockFs = buildMockFs(name, null)
+      const result = new ShadowProjectInputPlugin().collect(createCtx(mockFs))
+      const project = result.workspace?.projects.find(p => p.name === name)
+      expect(project?.projectConfig).toBeUndefined()
+    }))
+  })
+
+  it('project name is always preserved regardless of projectConfig presence', () => {
+    fc.assert(fc.property(projectNameGen, fc.boolean(), (name, hasConfig) => {
+      const mockFs = buildMockFs(name, hasConfig ? '{"mcp": {"names": []}}' : null)
+      const result = new ShadowProjectInputPlugin().collect(createCtx(mockFs))
+      const project = result.workspace?.projects.find(p => p.name === name)
+      expect(project?.name).toBe(name)
+    }))
+  })
+})

--- a/cli/src/plugins/ShadowProjectInputPlugin.ts
+++ b/cli/src/plugins/ShadowProjectInputPlugin.ts
@@ -1,5 +1,7 @@
 import type {CollectedInputContext, InputPluginContext, Project, Workspace} from '@/types'
+import type {ProjectConfig} from '@/types/ConfigTypes'
 
+import {parse as parseJsonc} from 'jsonc-parser'
 import {
   FilePathKind
 } from '@/types'
@@ -8,6 +10,31 @@ import {AbstractInputPlugin} from './AbstractInputPlugin'
 export class ShadowProjectInputPlugin extends AbstractInputPlugin {
   constructor() {
     super('ShadowProjectInputPlugin')
+  }
+
+  private loadProjectConfig(
+    projectName: string,
+    shadowProjectDir: string,
+    srcPath: string,
+    fs: InputPluginContext['fs'],
+    path: InputPluginContext['path'],
+    logger: InputPluginContext['logger']
+  ): ProjectConfig | undefined {
+    const configPath = path.join(shadowProjectDir, srcPath, projectName, 'project.jsonc')
+    if (!fs.existsSync(configPath)) return void 0
+    try {
+      const raw = fs.readFileSync(configPath, 'utf8')
+      const errors: import('jsonc-parser').ParseError[] = []
+      const result = parseJsonc(raw, errors) as ProjectConfig
+      if (errors.length > 0) {
+        logger.warn(`failed to parse project.jsonc for ${projectName}`, {path: configPath, errors})
+        return void 0
+      }
+      return result
+    } catch (e) {
+      logger.warn(`failed to parse project.jsonc for ${projectName}`, {path: configPath, error: e})
+      return void 0
+    }
   }
 
   collect(ctx: InputPluginContext): Partial<CollectedInputContext> {
@@ -26,10 +53,12 @@ export class ShadowProjectInputPlugin extends AbstractInputPlugin {
         for (const entry of entries) {
           if (entry.isDirectory()) {
             const isTheShadowSourceProject = entry.name === shadowSourceProjectName // Other projects should have their output files cleaned normally // Only mark the shadow source project itself (e.g., aindex) as prompt source project
+            const projectConfig = this.loadProjectConfig(entry.name, shadowProjectDir, options.shadowSourceProject.project.src, fs, path, logger)
 
             shadowProjects.push({
               name: entry.name,
               ...isTheShadowSourceProject && {isPromptSourceProject: true}, // This protects source files in the shadow source project from being cleaned // Only true for the shadow source project itself (e.g., aindex)
+              ...projectConfig != null && {projectConfig},
               dirFromWorkspacePath: {
                 pathKind: FilePathKind.Relative,
                 path: entry.name,
@@ -53,10 +82,12 @@ export class ShadowProjectInputPlugin extends AbstractInputPlugin {
         for (const entry of entries) {
           if (entry.isDirectory() && !entry.name.startsWith('.')) {
             const isTheShadowSourceProject = entry.name === shadowSourceProjectName
+            const projectConfig = this.loadProjectConfig(entry.name, shadowProjectDir, options.shadowSourceProject.project.src, fs, path, logger)
 
             shadowProjects.push({
               name: entry.name,
               ...isTheShadowSourceProject && {isPromptSourceProject: true},
+              ...projectConfig != null && {projectConfig},
               dirFromWorkspacePath: {
                 pathKind: FilePathKind.Relative,
                 path: entry.name,

--- a/cli/src/plugins/WindsurfOutputPlugin.projectConfig.test.ts
+++ b/cli/src/plugins/WindsurfOutputPlugin.projectConfig.test.ts
@@ -1,0 +1,237 @@
+import type {OutputPluginContext} from '@/types'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {collectFileNames, createMockProject, createMockRulePrompt} from './__testUtils__'
+import {WindsurfOutputPlugin} from './WindsurfOutputPlugin'
+
+class TestableWindsurfOutputPlugin extends WindsurfOutputPlugin {
+  private mockHomeDir: string | null = null
+
+  public setMockHomeDir(dir: string | null): void {
+    this.mockHomeDir = dir
+  }
+
+  protected override getHomeDir(): string {
+    if (this.mockHomeDir != null) return this.mockHomeDir
+    return super.getHomeDir()
+  }
+}
+
+function createMockContext(
+  tempDir: string,
+  rules: unknown[],
+  projects: unknown[]
+): OutputPluginContext {
+  return {
+    collectedInputContext: {
+      workspace: {
+        projects: projects as never,
+        directory: {
+          pathKind: 1,
+          path: tempDir,
+          basePath: tempDir,
+          getDirectoryName: () => 'workspace',
+          getAbsolutePath: () => tempDir
+        }
+      },
+      ideConfigFiles: [],
+      rules: rules as never,
+      fastCommands: [],
+      skills: [],
+      globalMemory: void 0,
+      aiAgentIgnoreConfigFiles: []
+    },
+    logger: {
+      debug: vi.fn(),
+      trace: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    } as never,
+    fs,
+    path,
+    glob: vi.fn() as never
+  }
+}
+
+describe('windsurfOutputPlugin - projectConfig filtering', () => {
+  let tempDir: string,
+    plugin: TestableWindsurfOutputPlugin
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'windsurf-proj-config-test-'))
+    plugin = new TestableWindsurfOutputPlugin()
+    plugin.setMockHomeDir(tempDir)
+  })
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tempDir, {recursive: true, force: true})
+    }
+    catch {}
+  })
+
+  describe('registerProjectOutputFiles', () => {
+    it('should include all project rules when no projectConfig', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [createMockProject('proj1', tempDir, 'proj1')]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.md')
+      expect(fileNames).toContain('rule-test-rule2.md')
+    })
+
+    it('should filter rules by include in projectConfig', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.md')
+      expect(fileNames).not.toContain('rule-test-rule2.md')
+    })
+
+    it('should filter rules by exclude in projectConfig', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {exclude: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).not.toContain('rule-test-rule1.md')
+      expect(fileNames).toContain('rule-test-rule2.md')
+    })
+
+    it('should expand include with subSeries', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'uniapp3', 'project'),
+        createMockRulePrompt('test', 'rule3', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {
+          rules: {
+            include: ['uniapp'],
+            subSeries: {uniapp: ['uniapp3']}
+          }
+        })
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.md')
+      expect(fileNames).toContain('rule-test-rule2.md')
+      expect(fileNames).not.toContain('rule-test-rule3.md')
+    })
+
+    it('should include rules without seriName regardless of include filter', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', void 0, 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = collectFileNames(results)
+
+      expect(fileNames).toContain('rule-test-rule1.md')
+      expect(fileNames).not.toContain('rule-test-rule2.md')
+    })
+
+    it('should filter independently for each project', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
+        createMockRulePrompt('test', 'rule2', 'vue', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}}),
+        createMockProject('proj2', tempDir, 'proj2', {rules: {include: ['vue']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const fileNames = results.map(r => ({
+        path: r.path,
+        fileName: r.path.split(/[/\\]/).pop()
+      }))
+
+      expect(fileNames.some(f => f.path.includes('proj1') && f.fileName === 'rule-test-rule1.md')).toBe(true)
+      expect(fileNames.some(f => f.path.includes('proj1') && f.fileName === 'rule-test-rule2.md')).toBe(false)
+      expect(fileNames.some(f => f.path.includes('proj2') && f.fileName === 'rule-test-rule2.md')).toBe(true)
+      expect(fileNames.some(f => f.path.includes('proj2') && f.fileName === 'rule-test-rule1.md')).toBe(false)
+    })
+
+    it('should return empty when include matches nothing', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['react']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputFiles(ctx)
+      const ruleFiles = results.filter(r => r.path.includes('rule-'))
+
+      expect(ruleFiles).toHaveLength(0)
+    })
+  })
+
+  describe('registerProjectOutputDirs', () => {
+    it('should not register rules dir when all rules filtered out', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['react']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputDirs(ctx)
+      const rulesDirs = results.filter(r => r.path.includes('rules'))
+
+      expect(rulesDirs).toHaveLength(0)
+    })
+
+    it('should register rules dir when rules match filter', async () => {
+      const rules = [
+        createMockRulePrompt('test', 'rule1', 'uniapp', 'project')
+      ]
+      const projects = [
+        createMockProject('proj1', tempDir, 'proj1', {rules: {include: ['uniapp']}})
+      ]
+      const ctx = createMockContext(tempDir, rules, projects)
+
+      const results = await plugin.registerProjectOutputDirs(ctx)
+      const rulesDirs = results.filter(r => r.path.includes('rules'))
+
+      expect(rulesDirs.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/cli/src/plugins/WindsurfOutputPlugin.ts
+++ b/cli/src/plugins/WindsurfOutputPlugin.ts
@@ -13,6 +13,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import {buildMarkdownWithFrontMatter} from '@truenine/md-compiler/markdown'
 import {FilePathKind} from '@/types'
+import {filterRulesByProjectConfig} from '@/utils/ruleFilter'
 import {AbstractOutputPlugin} from './AbstractOutputPlugin'
 
 const CODEIUM_WINDSURF_DIR = '.codeium/windsurf'
@@ -218,13 +219,17 @@ export class WindsurfOutputPlugin extends AbstractOutputPlugin {
   async registerProjectOutputDirs(ctx: OutputPluginContext): Promise<RelativePath[]> {
     const results: RelativePath[] = []
     const {workspace, rules} = ctx.collectedInputContext
-    const projectRules = rules?.filter(r => r.scope === 'project')
 
-    if (projectRules == null || projectRules.length === 0) return results
+    if (rules == null || rules.length === 0) return results
 
     for (const project of workspace.projects) {
       const projectDir = project.dirFromWorkspacePath
       if (projectDir == null) continue
+      const projectRules = filterRulesByProjectConfig(
+        rules.filter(r => r.scope === 'project'),
+        project.projectConfig
+      )
+      if (projectRules.length === 0) continue
       const rulesDirPath = path.join(projectDir.path, WINDSURF_RULES_DIR, WINDSURF_RULES_SUBDIR)
       results.push({
         pathKind: FilePathKind.Relative,
@@ -240,12 +245,15 @@ export class WindsurfOutputPlugin extends AbstractOutputPlugin {
   async registerProjectOutputFiles(ctx: OutputPluginContext): Promise<RelativePath[]> {
     const results: RelativePath[] = []
     const {workspace, rules} = ctx.collectedInputContext
-    const projectRules = rules?.filter(r => r.scope === 'project')
 
-    if (projectRules != null && projectRules.length > 0) {
+    if (rules != null && rules.length > 0) {
       for (const project of workspace.projects) {
         const projectDir = project.dirFromWorkspacePath
         if (projectDir == null) continue
+        const projectRules = filterRulesByProjectConfig(
+          rules.filter(r => r.scope === 'project'),
+          project.projectConfig
+        )
         for (const rule of projectRules) {
           const fileName = this.buildRuleFileName(rule)
           const filePath = path.join(projectDir.path, WINDSURF_RULES_DIR, WINDSURF_RULES_SUBDIR, fileName)
@@ -268,11 +276,15 @@ export class WindsurfOutputPlugin extends AbstractOutputPlugin {
     const fileResults: WriteResult[] = []
     const {workspace, rules} = ctx.collectedInputContext
 
-    const projectRules = rules?.filter(r => r.scope === 'project')
-    if (projectRules != null && projectRules.length > 0) {
+    if (rules != null && rules.length > 0) {
       for (const project of workspace.projects) {
         const projectDir = project.dirFromWorkspacePath
         if (projectDir == null) continue
+        const projectRules = filterRulesByProjectConfig(
+          rules.filter(r => r.scope === 'project'),
+          project.projectConfig
+        )
+        if (projectRules.length === 0) continue
         const rulesDir = path.join(projectDir.basePath, projectDir.path, WINDSURF_RULES_DIR, WINDSURF_RULES_SUBDIR)
         for (const rule of projectRules) {
           const result = await this.writeRuleFile(ctx, rulesDir, rule, projectDir.basePath, path.join(projectDir.path, WINDSURF_RULES_DIR, WINDSURF_RULES_SUBDIR))

--- a/cli/src/plugins/__testUtils__.ts
+++ b/cli/src/plugins/__testUtils__.ts
@@ -1,0 +1,65 @@
+import type {Project, RulePrompt} from '@/types'
+import type {RelativePath} from '@/types/FileSystemTypes'
+import {FilePathKind, NamingCaseKind, PromptKind} from '@/types'
+
+export function createMockRulePrompt(
+  series: string,
+  ruleName: string,
+  seriName: string | undefined,
+  scope: 'global' | 'project' = 'project'
+): RulePrompt {
+  const content = '# Rule body'
+  const base = {
+    type: PromptKind.Rule,
+    content,
+    length: content.length,
+    filePathKind: FilePathKind.Relative,
+    dir: {
+      pathKind: FilePathKind.Relative,
+      path: '.',
+      basePath: '',
+      getDirectoryName: () => '.',
+      getAbsolutePath: () => '.'
+    },
+    markdownContents: [],
+    yamlFrontMatter: {
+      description: 'Test rule',
+      globs: ['**/*.ts'],
+      namingCase: NamingCaseKind.KebabCase
+    },
+    series,
+    ruleName,
+    globs: ['**/*.ts'],
+    scope
+  }
+
+  return seriName != null
+    ? {...base, seriName} as RulePrompt
+    : base as RulePrompt
+}
+
+export function createMockProject(
+  name: string,
+  basePath: string,
+  projectPath: string,
+  projectConfig?: unknown
+): Project {
+  return {
+    name,
+    dirFromWorkspacePath: {
+      pathKind: FilePathKind.Relative,
+      path: projectPath,
+      basePath,
+      getDirectoryName: () => name,
+      getAbsolutePath: () => `${basePath}/${projectPath}`
+    },
+    ...projectConfig != null && {projectConfig: projectConfig as never}
+  }
+}
+
+export function collectFileNames(results: RelativePath[]): string[] {
+  return results.map(r => {
+    const parts = r.path.split(/[/\\]/)
+    return parts.at(-1) ?? r.path
+  })
+}

--- a/cli/src/types/ConfigTypes.ts
+++ b/cli/src/types/ConfigTypes.ts
@@ -74,6 +74,21 @@ export interface FastCommandSeriesOptions {
   readonly pluginOverrides?: Record<string, FastCommandSeriesPluginOverride>
 }
 
+export interface McpProjectConfig {
+  readonly names?: readonly string[]
+}
+
+export interface RulesProjectConfig {
+  readonly include?: readonly string[]
+  readonly exclude?: readonly string[]
+  readonly subSeries?: Readonly<Record<string, readonly string[]>>
+}
+
+export interface ProjectConfig {
+  readonly mcp?: McpProjectConfig
+  readonly rules?: RulesProjectConfig
+}
+
 /**
  * Options for ConfigLoader
  */

--- a/cli/src/types/ExportMetadataTypes.ts
+++ b/cli/src/types/ExportMetadataTypes.ts
@@ -38,6 +38,7 @@ export interface RuleExportMetadata extends BaseExportMetadata {
   readonly globs: readonly string[]
   readonly description: string
   readonly scope?: RuleScope
+  readonly seriName?: string
 }
 
 export interface SubAgentExportMetadata extends BaseExportMetadata {
@@ -181,10 +182,12 @@ export function validateRuleMetadata(
 
   if (typeof metadata['description'] !== 'string' || metadata['description'].length === 0) errors.push(`Missing or empty required field "description"${prefix}`)
 
-  const {scope} = metadata
+  const {scope, seriName} = metadata
   if (scope != null && scope !== 'project' && scope !== 'global') errors.push(`Field "scope" must be "project" or "global"${prefix}`)
 
   if (scope == null) warnings.push(`Using default value for optional field "scope": "project"${prefix}`)
+
+  if (seriName != null && typeof seriName !== 'string') errors.push(`Field "seriName" must be a string${prefix}`)
 
   return {valid: errors.length === 0, errors, warnings}
 }

--- a/cli/src/types/InputTypes.ts
+++ b/cli/src/types/InputTypes.ts
@@ -1,3 +1,4 @@
+import type {ProjectConfig} from '@/types/ConfigTypes'
 import type {FileContent, Path, RelativePath} from '@/types/FileSystemTypes'
 import type {
   FilePathKind,
@@ -22,6 +23,7 @@ export interface Project {
   readonly rootMemoryPrompt?: ProjectRootMemoryPrompt
   readonly childMemoryPrompts?: readonly ProjectChildrenMemoryPrompt[]
   readonly isPromptSourceProject?: boolean
+  readonly projectConfig?: ProjectConfig
 }
 
 export interface Workspace {
@@ -71,6 +73,7 @@ export interface RulePrompt extends Prompt<PromptKind.Rule, RuleYAMLFrontMatter,
   readonly ruleName: string
   readonly globs: readonly string[]
   readonly scope: RuleScope
+  readonly seriName?: string
   readonly rawMdxContent?: string
 }
 

--- a/cli/src/types/PromptTypes.ts
+++ b/cli/src/types/PromptTypes.ts
@@ -128,6 +128,7 @@ export interface KiroPowerYAMLFrontMatter extends SkillsYAMLFrontMatter {
 export interface RuleYAMLFrontMatter extends CommonYAMLFrontMatter {
   readonly globs: readonly string[]
   readonly scope?: RuleScope
+  readonly seriName?: string
 }
 
 /**

--- a/cli/src/utils/ruleFilter.property.test.ts
+++ b/cli/src/utils/ruleFilter.property.test.ts
@@ -1,0 +1,191 @@
+import type {ProjectConfig} from '@/types/ConfigTypes'
+import type {RulePrompt} from '@/types/InputTypes'
+import * as fc from 'fast-check'
+import {describe, expect, it} from 'vitest'
+import {FilePathKind, PromptKind} from '@/types'
+import {expandWithSubSeries, filterRulesByProjectConfig} from './ruleFilter'
+
+function createMockRulePrompt(seriName: string | undefined): RulePrompt {
+  const content = '# Rule body'
+  return {
+    type: PromptKind.Rule,
+    content,
+    length: content.length,
+    filePathKind: FilePathKind.Relative,
+    dir: {pathKind: FilePathKind.Relative, path: '.', basePath: '', getDirectoryName: () => '.', getAbsolutePath: () => '.'},
+    markdownContents: [],
+    yamlFrontMatter: {description: 'Test rule', globs: ['**/*.ts']},
+    series: 'test',
+    ruleName: 'test-rule',
+    globs: ['**/*.ts'],
+    scope: 'project',
+    seriName
+  }
+}
+
+const seriNameGen = fc.stringMatching(/^[a-z0-9]{1,20}$/)
+const seriNameArrayGen = fc.array(seriNameGen, {minLength: 0, maxLength: 10})
+
+const subSeriesGen = fc.dictionary(seriNameGen, seriNameArrayGen) // Generator for subSeries: Record<string, readonly string[]>
+
+describe('expandWithSubSeries property tests', () => {
+  it('should always include all input names in result', () => {
+    fc.assert(
+      fc.property(seriNameArrayGen, subSeriesGen, (names, subSeries) => {
+        const result = expandWithSubSeries(names, subSeries)
+        for (const name of names) expect(result).toContain(name)
+      }),
+      {numRuns: 100}
+    )
+  })
+
+  it('should never produce duplicates', () => {
+    fc.assert(
+      fc.property(seriNameArrayGen, subSeriesGen, (names, subSeries) => {
+        const result = expandWithSubSeries(names, subSeries)
+        const uniqueResult = [...new Set(result)]
+        expect(result).toHaveLength(uniqueResult.length)
+      }),
+      {numRuns: 100}
+    )
+  })
+
+  it('should be idempotent when subSeries has no matching keys', () => {
+    fc.assert(
+      fc.property(seriNameArrayGen, names => {
+        const emptySubSeries: Record<string, readonly string[]> = {}
+        const result1 = expandWithSubSeries(names, emptySubSeries)
+        const result2 = expandWithSubSeries(result1, emptySubSeries)
+        expect(result1).toEqual(result2)
+      }),
+      {numRuns: 100}
+    )
+  })
+
+  it('should expand result size >= unique input size', () => {
+    fc.assert(
+      fc.property(seriNameArrayGen, subSeriesGen, (names, subSeries) => {
+        const result = expandWithSubSeries(names, subSeries)
+        const uniqueNames = [...new Set(names)]
+        expect(result.length).toBeGreaterThanOrEqual(uniqueNames.length)
+      }),
+      {numRuns: 100}
+    )
+  })
+})
+
+describe('filterRulesByProjectConfig property tests', () => {
+  it('should return all rules when projectConfig is undefined', async () => {
+    await fc.assert(
+      fc.asyncProperty(seriNameArrayGen, async seriNames => {
+        const rules = seriNames.map(createMockRulePrompt)
+        const result = filterRulesByProjectConfig(rules, void 0)
+        expect(result).toHaveLength(rules.length)
+      }),
+      {numRuns: 100}
+    )
+  })
+
+  it('should filter rules deterministically', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        seriNameArrayGen,
+        seriNameArrayGen,
+        seriNameArrayGen,
+        async (ruleNames, includeNames, excludeNames) => {
+          const rules = ruleNames.map(createMockRulePrompt)
+          const projectConfig: ProjectConfig = {
+            rules: {include: includeNames, exclude: excludeNames}
+          }
+          const result1 = filterRulesByProjectConfig(rules, projectConfig)
+          const result2 = filterRulesByProjectConfig(rules, projectConfig)
+          expect(result1).toEqual(result2)
+        }
+      ),
+      {numRuns: 100}
+    )
+  })
+
+  it('should return subset when include is specified', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        seriNameArrayGen,
+        seriNameArrayGen,
+        async (ruleNames, includeNames) => {
+          const rules = ruleNames.map(createMockRulePrompt)
+          const projectConfig: ProjectConfig = {
+            rules: {include: includeNames}
+          }
+          const result = filterRulesByProjectConfig(rules, projectConfig)
+          expect(result.length).toBeLessThanOrEqual(rules.length)
+        }
+      ),
+      {numRuns: 100}
+    )
+  })
+
+  it('should never return rules with excluded seriName', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        seriNameArrayGen,
+        seriNameArrayGen,
+        async (ruleNames, excludeNames) => {
+          const rules = ruleNames.map(createMockRulePrompt)
+          const projectConfig: ProjectConfig = {
+            rules: {exclude: excludeNames}
+          }
+          const result = filterRulesByProjectConfig(rules, projectConfig)
+          for (const excluded of excludeNames) {
+            const hasExcluded = result.some(r => r.seriName === excluded)
+            expect(hasExcluded).toBe(false)
+          }
+        }
+      ),
+      {numRuns: 100}
+    )
+  })
+
+  it('should always include rules with undefined seriName', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        seriNameArrayGen,
+        seriNameArrayGen,
+        seriNameArrayGen,
+        async (definedNames, includeNames, excludeNames) => {
+          const rules = [
+            ...definedNames.map(createMockRulePrompt),
+            createMockRulePrompt(void 0)
+          ]
+          const projectConfig: ProjectConfig = {
+            rules: {include: includeNames, exclude: excludeNames}
+          }
+          const result = filterRulesByProjectConfig(rules, projectConfig)
+          const hasUndefinedSeriName = result.some(r => r.seriName === void 0)
+          expect(hasUndefinedSeriName).toBe(true)
+        }
+      ),
+      {numRuns: 100}
+    )
+  })
+
+  it('subSeries expansion should include parent and children', async () => {
+    const parentGen = seriNameGen
+    const childrenGen = fc.array(seriNameGen, {minLength: 1, maxLength: 5})
+
+    await fc.assert(
+      fc.asyncProperty(parentGen, childrenGen, async (parent, children) => {
+        const rules = [parent, ...children].map(createMockRulePrompt)
+        const projectConfig: ProjectConfig = {
+          rules: {
+            include: [parent],
+            subSeries: {[parent]: children}
+          }
+        }
+        const result = filterRulesByProjectConfig(rules, projectConfig)
+        expect(result.map(r => r.seriName)).toContain(parent)
+        for (const child of children) expect(result.map(r => r.seriName)).toContain(child)
+      }),
+      {numRuns: 100}
+    )
+  })
+})

--- a/cli/src/utils/ruleFilter.test.ts
+++ b/cli/src/utils/ruleFilter.test.ts
@@ -1,0 +1,244 @@
+import type {ProjectConfig} from '@/types/ConfigTypes'
+import type {RulePrompt} from '@/types/InputTypes'
+import {describe, expect, it} from 'vitest'
+import {FilePathKind, PromptKind} from '@/types'
+import {expandWithSubSeries, filterRulesByProjectConfig} from './ruleFilter'
+
+function createMockRulePrompt(seriName: string | undefined): RulePrompt {
+  const content = '# Rule body'
+  return {
+    type: PromptKind.Rule,
+    content,
+    length: content.length,
+    filePathKind: FilePathKind.Relative,
+    dir: {pathKind: FilePathKind.Relative, path: '.', basePath: '', getDirectoryName: () => '.', getAbsolutePath: () => '.'},
+    markdownContents: [],
+    yamlFrontMatter: {description: 'Test rule', globs: ['**/*.ts']},
+    series: 'test',
+    ruleName: 'test-rule',
+    globs: ['**/*.ts'],
+    scope: 'project',
+    seriName
+  }
+}
+
+describe('expandWithSubSeries', () => {
+  it('should return same array when no subSeries match', () => {
+    const result = expandWithSubSeries(['uniapp'], {vue: ['vue2', 'vue3']})
+    expect(result).toEqual(['uniapp'])
+  })
+
+  it('should expand single name with children', () => {
+    const result = expandWithSubSeries(['uniapp'], {uniapp: ['uniapp2', 'uniapp3']})
+    expect(result).toEqual(['uniapp', 'uniapp2', 'uniapp3'])
+  })
+
+  it('should expand multiple names', () => {
+    const result = expandWithSubSeries(['uniapp', 'vue'], {
+      uniapp: ['uniapp2'],
+      vue: ['vue2', 'vue3']
+    })
+    expect(result).toEqual(['uniapp', 'vue', 'uniapp2', 'vue2', 'vue3'])
+  })
+
+  it('should deduplicate expanded names', () => {
+    const result = expandWithSubSeries(['uniapp', 'uniapp'], {uniapp: ['uniapp2', 'uniapp']})
+    expect(result).toEqual(['uniapp', 'uniapp2'])
+  })
+
+  it('should handle empty subSeries', () => {
+    const result = expandWithSubSeries(['uniapp'], {})
+    expect(result).toEqual(['uniapp'])
+  })
+
+  it('should handle empty names array', () => {
+    const result = expandWithSubSeries([], {uniapp: ['uniapp2']})
+    expect(result).toEqual([])
+  })
+})
+
+describe('filterRulesByProjectConfig', () => {
+  it('should return all rules when no projectConfig', () => {
+    const rules = [
+      createMockRulePrompt('uniapp'),
+      createMockRulePrompt('vue'),
+      createMockRulePrompt(void 0)
+    ]
+    const result = filterRulesByProjectConfig(rules, void 0)
+    expect(result).toHaveLength(3)
+  })
+
+  it('should return all rules when no rules config', () => {
+    const rules = [createMockRulePrompt('uniapp'), createMockRulePrompt('vue')]
+    const projectConfig: ProjectConfig = {mcp: {names: ['test']}}
+    const result = filterRulesByProjectConfig(rules, projectConfig)
+    expect(result).toHaveLength(2)
+  })
+
+  describe('include filtering', () => {
+    it('should include only matching seriName', () => {
+      const rules = [createMockRulePrompt('uniapp'), createMockRulePrompt('vue')]
+      const projectConfig: ProjectConfig = {rules: {include: ['uniapp']}}
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(1)
+      expect(result[0].seriName).toBe('uniapp')
+    })
+
+    it('should include all when seriName is undefined (backward compatible)', () => {
+      const rules = [createMockRulePrompt(void 0), createMockRulePrompt('vue')]
+      const projectConfig: ProjectConfig = {rules: {include: ['uniapp']}}
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(1)
+      expect(result[0].seriName).toBeUndefined()
+    })
+
+    it('should handle empty include array', () => {
+      const rules = [createMockRulePrompt('uniapp'), createMockRulePrompt('vue')]
+      const projectConfig: ProjectConfig = {rules: {include: []}}
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(2)
+    })
+
+    it('should handle multiple include values', () => {
+      const rules = [
+        createMockRulePrompt('uniapp'),
+        createMockRulePrompt('vue'),
+        createMockRulePrompt('react')
+      ]
+      const projectConfig: ProjectConfig = {rules: {include: ['uniapp', 'vue']}}
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(2)
+      expect(result.map(r => r.seriName)).toContain('uniapp')
+      expect(result.map(r => r.seriName)).toContain('vue')
+    })
+  })
+
+  describe('exclude filtering', () => {
+    it('should exclude matching seriName', () => {
+      const rules = [createMockRulePrompt('uniapp'), createMockRulePrompt('vue')]
+      const projectConfig: ProjectConfig = {rules: {exclude: ['uniapp']}}
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(1)
+      expect(result[0].seriName).toBe('vue')
+    })
+
+    it('should keep undefined seriName even when exclude exists (backward compatible)', () => {
+      const rules = [createMockRulePrompt(void 0), createMockRulePrompt('uniapp')]
+      const projectConfig: ProjectConfig = {rules: {exclude: ['uniapp']}}
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(1)
+      expect(result[0].seriName).toBeUndefined()
+    })
+
+    it('should handle empty exclude array', () => {
+      const rules = [createMockRulePrompt('uniapp'), createMockRulePrompt('vue')]
+      const projectConfig: ProjectConfig = {rules: {exclude: []}}
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(2)
+    })
+  })
+
+  describe('include + exclude combination', () => {
+    it('should apply include then exclude', () => {
+      const rules = [
+        createMockRulePrompt('uniapp'),
+        createMockRulePrompt('vue'),
+        createMockRulePrompt('react')
+      ]
+      const projectConfig: ProjectConfig = {
+        rules: {include: ['uniapp', 'vue'], exclude: ['uniapp']}
+      }
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(1)
+      expect(result[0].seriName).toBe('vue')
+    })
+  })
+
+  describe('subSeries expansion', () => {
+    it('should expand include with subSeries', () => {
+      const rules = [
+        createMockRulePrompt('uniapp'),
+        createMockRulePrompt('uniapp3'),
+        createMockRulePrompt('vue')
+      ]
+      const projectConfig: ProjectConfig = {
+        rules: {
+          include: ['uniapp'],
+          subSeries: {uniapp: ['uniapp2', 'uniapp3']}
+        }
+      }
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(2)
+      expect(result.map(r => r.seriName)).toContain('uniapp')
+      expect(result.map(r => r.seriName)).toContain('uniapp3')
+    })
+
+    it('should expand exclude with subSeries', () => {
+      const rules = [
+        createMockRulePrompt('uniapp'),
+        createMockRulePrompt('uniapp3'),
+        createMockRulePrompt('vue')
+      ]
+      const projectConfig: ProjectConfig = {
+        rules: {
+          exclude: ['uniapp'],
+          subSeries: {uniapp: ['uniapp3']}
+        }
+      }
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(1)
+      expect(result[0].seriName).toBe('vue')
+    })
+
+    it('should expand both include and exclude', () => {
+      const rules = [
+        createMockRulePrompt('uniapp'),
+        createMockRulePrompt('uniapp2'),
+        createMockRulePrompt('uniapp3'),
+        createMockRulePrompt('vue')
+      ]
+      const projectConfig: ProjectConfig = {
+        rules: {
+          include: ['uniapp'],
+          exclude: ['uniapp2'],
+          subSeries: {
+            uniapp: ['uniapp2', 'uniapp3']
+          }
+        }
+      }
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(2)
+      expect(result.map(r => r.seriName)).toContain('uniapp')
+      expect(result.map(r => r.seriName)).toContain('uniapp3')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty rules array', () => {
+      const projectConfig: ProjectConfig = {rules: {include: ['uniapp']}}
+      const result = filterRulesByProjectConfig([], projectConfig)
+      expect(result).toHaveLength(0)
+    })
+
+    it('should handle all rules excluded', () => {
+      const rules = [createMockRulePrompt('uniapp'), createMockRulePrompt('vue')]
+      const projectConfig: ProjectConfig = {
+        rules: {include: ['uniapp'], exclude: ['uniapp']}
+      }
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(0)
+    })
+
+    it('should handle subSeries not matching any include', () => {
+      const rules = [createMockRulePrompt('uniapp'), createMockRulePrompt('vue')]
+      const projectConfig: ProjectConfig = {
+        rules: {
+          include: ['react'],
+          subSeries: {react: ['react-native']}
+        }
+      }
+      const result = filterRulesByProjectConfig(rules, projectConfig)
+      expect(result).toHaveLength(0)
+    })
+  })
+})

--- a/cli/src/utils/ruleFilter.ts
+++ b/cli/src/utils/ruleFilter.ts
@@ -1,0 +1,71 @@
+import type {ProjectConfig} from '@/types/ConfigTypes'
+import type {RulePrompt} from '@/types/InputTypes'
+
+/**
+ * Expand names with their subSeries definitions.
+ * Each name in `names` is expanded to include its children from `subSeries`.
+ * Expansion is only one level deep.
+ */
+export function expandWithSubSeries(
+  names: readonly string[],
+  subSeries: Readonly<Record<string, readonly string[]>>
+): readonly string[] {
+  const result = new Set<string>(names)
+
+  for (const name of names) {
+    if (Object.hasOwn(subSeries, name)) { // (e.g., keys like "constructor" would access Object.prototype.constructor) // Use Object.prototype.hasOwnProperty to avoid prototype pollution
+      const children = subSeries[name]
+      if (children != null) {
+        for (const child of children) result.add(child)
+      }
+    }
+  }
+
+  return [...result]
+}
+
+/**
+ * Filter rules based on project configuration.
+ *
+ * Logic:
+ * 1. If no projectConfig.rules exists, return all rules (backward compatible)
+ * 2. Expand include/exclude with subSeries mappings
+ * 3. Rules without seriName are always included (backward compatible)
+ * 4. Apply include filter first (if exists)
+ * 5. Apply exclude filter second (if exists)
+ *
+ * @param rules - Array of RulePrompt to filter
+ * @param projectConfig - Project configuration containing rules config
+ * @returns Filtered array of RulePrompt
+ */
+export function filterRulesByProjectConfig(
+  rules: readonly RulePrompt[],
+  projectConfig: ProjectConfig | undefined
+): readonly RulePrompt[] {
+  const rulesConfig = projectConfig?.rules
+  if (rulesConfig == null) return rules
+
+  const {include, exclude, subSeries} = rulesConfig
+
+  let effectiveInclude = include // Expand include with subSeries
+  if (effectiveInclude != null && subSeries != null) effectiveInclude = expandWithSubSeries(effectiveInclude, subSeries)
+
+  let effectiveExclude = exclude // Expand exclude with subSeries
+  if (effectiveExclude != null && subSeries != null) effectiveExclude = expandWithSubSeries(effectiveExclude, subSeries)
+
+  return rules.filter(rule => {
+    if (rule.seriName == null) { // seriName undefined → always output (backward compatible)
+      return true
+    }
+
+    if (effectiveInclude != null && effectiveInclude.length > 0) { // Include filter
+      if (!effectiveInclude.includes(rule.seriName)) return false
+    }
+
+    if (effectiveExclude != null && effectiveExclude.length > 0) { // Exclude filter
+      if (effectiveExclude.includes(rule.seriName)) return false
+    }
+
+    return true
+  })
+}

--- a/doc/next-env.d.ts
+++ b/doc/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ catalogs:
     fs-extra:
       specifier: ^11.3.3
       version: 11.3.3
+    jsonc-parser:
+      specifier: ^2.3.1
+      version: 2.3.1
     lucide-react:
       specifier: ^0.563.0
       version: 0.563.0
@@ -206,6 +209,9 @@ importers:
       fs-extra:
         specifier: 'catalog:'
         version: 11.3.3
+      jsonc-parser:
+        specifier: 'catalog:'
+        version: 2.3.1
       picocolors:
         specifier: 'catalog:'
         version: 1.1.1
@@ -2904,6 +2910,9 @@ packages:
   jsonc-eslint-parser@2.4.2:
     resolution: {integrity: sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  jsonc-parser@2.3.1:
+    resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
@@ -6319,6 +6328,8 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       semver: 7.7.4
+
+  jsonc-parser@2.3.1: {}
 
   jsonfile@6.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,3 +58,4 @@ catalog:
   vite: ^7.3.1
   vitest: ^4.0.18
   yaml: ^2.8.2
+  jsonc-parser: ^2.3.1


### PR DESCRIPTION
## Summary

This PR implements the `project.jsonc` configuration support for filtering rules by `seriName` across all output plugins.

### Changes

- **Core filtering logic**: Added `src/utils/ruleFilter.ts` with `filterRulesByProjectConfig()` function
  - Support for `include`/`exclude` filtering
  - Support for `subSeries` expansion (one level deep)
  - Backward compatible: rules without `seriName` are always included

- **Output plugins updated** (all 4 plugins now respect project.jsonc rules config):
  - `CursorOutputPlugin`
  - `ClaudeCodeCLIOutputPlugin` 
  - `WindsurfOutputPlugin`
  - `KiroCLIOutputPlugin`

- **Comprehensive testing**:
  - 22 unit tests for ruleFilter
  - 10 property tests using fast-check
  - 35 integration tests across all plugins
  - All 756 tests passing

### Usage Example

```jsonc
// project.jsonc
{
  "rules": {
    "include": ["uniapp"],
    "exclude": ["legacy"],
    "subSeries": {
      "uniapp": ["uniapp2", "uniapp3"]
    }
  }
}
```

### Testing

```bash
pnpm -F memory-sync test
```

All tests pass ✅