### PR TITLE
chore: bump version to 2026.10219.10305

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-cli",
   "type": "module",
-  "version": "2026.10219.10049",
+  "version": "2026.10219.10305",
   "description": "TrueNine Memory Synchronization CLI",
   "author": "TrueNine",
   "license": "AGPL-3.0-only",

--- a/cli/public/tnmsc.example.json
+++ b/cli/public/tnmsc.example.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026.10219.10049",
+  "version": "2026.10219.10305",
   "workspaceDir": "~/project",
   "shadowSourceProject": {
     "name": "tnmsc-shadow",

--- a/doc/package.json
+++ b/doc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-docs",
   "private": true,
-  "version": "2026.10219.10049",
+  "version": "2026.10219.10305",
   "description": "Documentation site for @truenine/memory-sync, built with Next.js 16 and MDX.",
   "scripts": {
     "dev": "next dev",

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-gui",
-  "version": "2026.10219.10049",
+  "version": "2026.10219.10305",
   "private": true,
   "engines": {
     "node": ">=25.2.1",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-sync-gui"
-version = "2026.10219.10049"
+version = "2026.10219.10305"
 description = "Memory Sync desktop GUI application"
 authors = ["TrueNine"]
 edition = "2021"

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "version": "2026.10219.10049",
+  "version": "2026.10219.10305",
   "productName": "Memory Sync",
   "identifier": "org.truenine.memory-sync",
   "build": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync",
-  "version": "2026.10219.10049",
+  "version": "2026.10219.10305",
   "description": "Cross-AI-tool prompt synchronisation toolkit (CLI + Tauri desktop GUI) — one ruleset, multi-target adaptation. Monorepo powered by pnpm + Turbo.",
   "license": "AGPL-3.0-only",
   "keywords": [

--- a/packages/init-bundle/public/public/tnmsc.example.json
+++ b/packages/init-bundle/public/public/tnmsc.example.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026.10219.10049",
+  "version": "2026.10219.10305",
   "workspaceDir": "~/project",
   "shadowSourceProject": {
     "name": "tnmsc-shadow",


### PR DESCRIPTION
## Summary

Version bump and additional updates following the project.jsonc rules filtering feature.

### Changes Since Last PR

- **Version update**: Bumped to `2026.10219.10305`
- All previous features from #21 included:
  - project.jsonc rules filtering with seriName support
  - include/exclude filtering
  - subSeries expansion
  - Full test coverage (756 tests)

### Testing

```bash
pnpm -F memory-sync test
```

All tests pass ✅