### PR TITLE
feat: subSeries 重构为子目录前缀映射

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-cli",
   "type": "module",
-  "version": "2026.10219.10305",
+  "version": "2026.10219.10518",
   "description": "TrueNine Memory Synchronization CLI",
   "author": "TrueNine",
   "license": "AGPL-3.0-only",

--- a/cli/public/tnmsc.example.json
+++ b/cli/public/tnmsc.example.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026.10219.10305",
+  "version": "2026.10219.10518",
   "workspaceDir": "~/project",
   "shadowSourceProject": {
     "name": "tnmsc-shadow",

--- a/cli/src/plugins/ClaudeCodeCLIOutputPlugin.projectConfig.test.ts
+++ b/cli/src/plugins/ClaudeCodeCLIOutputPlugin.projectConfig.test.ts
@@ -124,30 +124,6 @@ describe('claudeCodeCLIOutputPlugin - projectConfig filtering', () => {
       expect(fileNames).toContain('rule-test-rule2.md')
     })
 
-    it('should expand include with subSeries', async () => {
-      const rules = [
-        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
-        createMockRulePrompt('test', 'rule2', 'uniapp3', 'project'),
-        createMockRulePrompt('test', 'rule3', 'vue', 'project')
-      ]
-      const projects = [
-        createMockProject('proj1', tempDir, 'proj1', {
-          rules: {
-            include: ['uniapp'],
-            subSeries: {uniapp: ['uniapp3']}
-          }
-        })
-      ]
-      const ctx = createMockContext(tempDir, rules, projects)
-
-      const results = await plugin.registerProjectOutputFiles(ctx)
-      const fileNames = collectFileNames(results)
-
-      expect(fileNames).toContain('rule-test-rule1.md')
-      expect(fileNames).toContain('rule-test-rule2.md')
-      expect(fileNames).not.toContain('rule-test-rule3.md')
-    })
-
     it('should include rules without seriName regardless of include filter', async () => {
       const rules = [
         createMockRulePrompt('test', 'rule1', void 0, 'project'),

--- a/cli/src/plugins/ClaudeCodeCLIOutputPlugin.ts
+++ b/cli/src/plugins/ClaudeCodeCLIOutputPlugin.ts
@@ -1,7 +1,7 @@
 import type {OutputPluginContext, OutputWriteContext, RulePrompt, WriteResults} from '@/types'
 import type {RelativePath} from '@/types/FileSystemTypes'
 import * as path from 'node:path'
-import {filterRulesByProjectConfig} from '@/utils/ruleFilter'
+import {applySubSeriesGlobPrefix, filterRulesByProjectConfig} from '@/utils/ruleFilter'
 import {BaseCLIOutputPlugin} from './BaseCLIOutputPlugin'
 
 const PROJECT_MEMORY_FILE = 'CLAUDE.md'
@@ -52,8 +52,11 @@ export class ClaudeCodeCLIOutputPlugin extends BaseCLIOutputPlugin {
     if (rules == null || rules.length === 0) return results
     for (const project of ctx.collectedInputContext.workspace.projects) {
       if (project.dirFromWorkspacePath == null) continue
-      const projectRules = filterRulesByProjectConfig(
-        rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+      const projectRules = applySubSeriesGlobPrefix(
+        filterRulesByProjectConfig(
+          rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+          project.projectConfig
+        ),
         project.projectConfig
       )
       if (projectRules.length === 0) continue
@@ -69,8 +72,11 @@ export class ClaudeCodeCLIOutputPlugin extends BaseCLIOutputPlugin {
     if (rules == null || rules.length === 0) return results
     for (const project of ctx.collectedInputContext.workspace.projects) {
       if (project.dirFromWorkspacePath == null) continue
-      const projectRules = filterRulesByProjectConfig(
-        rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+      const projectRules = applySubSeriesGlobPrefix(
+        filterRulesByProjectConfig(
+          rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+          project.projectConfig
+        ),
         project.projectConfig
       )
       for (const rule of projectRules) {
@@ -103,8 +109,11 @@ export class ClaudeCodeCLIOutputPlugin extends BaseCLIOutputPlugin {
     const ruleResults = []
     for (const project of ctx.collectedInputContext.workspace.projects) {
       if (project.dirFromWorkspacePath == null) continue
-      const projectRules = filterRulesByProjectConfig(
-        rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+      const projectRules = applySubSeriesGlobPrefix(
+        filterRulesByProjectConfig(
+          rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+          project.projectConfig
+        ),
         project.projectConfig
       )
       if (projectRules.length === 0) continue

--- a/cli/src/plugins/CursorOutputPlugin.projectConfig.test.ts
+++ b/cli/src/plugins/CursorOutputPlugin.projectConfig.test.ts
@@ -123,30 +123,6 @@ describe('cursorOutputPlugin - projectConfig filtering', () => {
       expect(fileNames).toContain('rule-test-rule2.mdc')
     })
 
-    it('should expand include with subSeries', async () => {
-      const rules = [
-        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
-        createMockRulePrompt('test', 'rule2', 'uniapp3', 'project'),
-        createMockRulePrompt('test', 'rule3', 'vue', 'project')
-      ]
-      const projects = [
-        createMockProject('proj1', tempDir, 'proj1', {
-          rules: {
-            include: ['uniapp'],
-            subSeries: {uniapp: ['uniapp3']}
-          }
-        })
-      ]
-      const ctx = createMockContext(tempDir, rules, projects)
-
-      const results = await plugin.registerProjectOutputFiles(ctx)
-      const fileNames = collectFileNames(results)
-
-      expect(fileNames).toContain('rule-test-rule1.mdc')
-      expect(fileNames).toContain('rule-test-rule2.mdc')
-      expect(fileNames).not.toContain('rule-test-rule3.mdc')
-    })
-
     it('should include rules without seriName regardless of include filter', async () => {
       const rules = [
         createMockRulePrompt('test', 'rule1', void 0, 'project'),

--- a/cli/src/plugins/CursorOutputPlugin.ts
+++ b/cli/src/plugins/CursorOutputPlugin.ts
@@ -14,7 +14,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import {buildMarkdownWithFrontMatter} from '@truenine/md-compiler/markdown'
 import {FilePathKind} from '@/types'
-import {filterRulesByProjectConfig} from '@/utils/ruleFilter'
+import {applySubSeriesGlobPrefix, filterRulesByProjectConfig} from '@/utils/ruleFilter'
 import {AbstractOutputPlugin} from './AbstractOutputPlugin'
 
 const GLOBAL_CONFIG_DIR = '.cursor'
@@ -257,8 +257,11 @@ export class CursorOutputPlugin extends AbstractOutputPlugin {
       for (const project of workspace.projects) {
         const projectDir = project.dirFromWorkspacePath
         if (projectDir == null) continue
-        const projectRules = filterRulesByProjectConfig(
-          rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+        const projectRules = applySubSeriesGlobPrefix(
+          filterRulesByProjectConfig(
+            rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+            project.projectConfig
+          ),
           project.projectConfig
         )
         for (const rule of projectRules) {
@@ -344,8 +347,11 @@ export class CursorOutputPlugin extends AbstractOutputPlugin {
       for (const project of workspace.projects) {
         const projectDir = project.dirFromWorkspacePath
         if (projectDir == null) continue
-        const projectRules = filterRulesByProjectConfig(
-          rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+        const projectRules = applySubSeriesGlobPrefix(
+          filterRulesByProjectConfig(
+            rules.filter(r => this.normalizeRuleScope(r) === 'project'),
+            project.projectConfig
+          ),
           project.projectConfig
         )
         if (projectRules.length === 0) continue

--- a/cli/src/plugins/KiroCLIOutputPlugin.projectConfig.test.ts
+++ b/cli/src/plugins/KiroCLIOutputPlugin.projectConfig.test.ts
@@ -123,30 +123,6 @@ describe('kiroCLIOutputPlugin - projectConfig filtering', () => {
       expect(fileNames).toContain('rule-test-rule2.md')
     })
 
-    it('should expand include with subSeries', async () => {
-      const rules = [
-        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
-        createMockRulePrompt('test', 'rule2', 'uniapp3', 'project'),
-        createMockRulePrompt('test', 'rule3', 'vue', 'project')
-      ]
-      const projects = [
-        createMockProject('proj1', tempDir, 'proj1', {
-          rules: {
-            include: ['uniapp'],
-            subSeries: {uniapp: ['uniapp3']}
-          }
-        })
-      ]
-      const ctx = createMockContext(tempDir, rules, projects)
-
-      const results = await plugin.registerProjectOutputFiles(ctx)
-      const fileNames = collectFileNames(results)
-
-      expect(fileNames).toContain('rule-test-rule1.md')
-      expect(fileNames).toContain('rule-test-rule2.md')
-      expect(fileNames).not.toContain('rule-test-rule3.md')
-    })
-
     it('should include rules without seriName regardless of include filter', async () => {
       const rules = [
         createMockRulePrompt('test', 'rule1', void 0, 'project'),

--- a/cli/src/plugins/KiroCLIOutputPlugin.ts
+++ b/cli/src/plugins/KiroCLIOutputPlugin.ts
@@ -12,7 +12,7 @@ import type {
   WriteResults
 } from '@/types'
 import type {RelativePath} from '@/types/FileSystemTypes'
-import {filterRulesByProjectConfig} from '@/utils/ruleFilter'
+import {applySubSeriesGlobPrefix, filterRulesByProjectConfig} from '@/utils/ruleFilter'
 import {AbstractOutputPlugin} from './AbstractOutputPlugin'
 import {KiroPowersRegistryWriter} from './registry/KiroPowersRegistryWriter'
 
@@ -97,8 +97,11 @@ export class KiroCLIOutputPlugin extends AbstractOutputPlugin {
       }
 
       if (rules != null && rules.length > 0) {
-        const projectRules = filterRulesByProjectConfig(
-          rules.filter(r => r.scope === 'project'),
+        const projectRules = applySubSeriesGlobPrefix(
+          filterRulesByProjectConfig(
+            rules.filter(r => r.scope === 'project'),
+            project.projectConfig
+          ),
           project.projectConfig
         )
         for (const rule of projectRules) {
@@ -228,8 +231,11 @@ export class KiroCLIOutputPlugin extends AbstractOutputPlugin {
       }
 
       if (rules != null && rules.length > 0) {
-        const projectRules = filterRulesByProjectConfig(
-          rules.filter(r => r.scope === 'project'),
+        const projectRules = applySubSeriesGlobPrefix(
+          filterRulesByProjectConfig(
+            rules.filter(r => r.scope === 'project'),
+            project.projectConfig
+          ),
           project.projectConfig
         )
         for (const rule of projectRules) fileResults.push(await this.writeRuleSteeringFile(ctx, project, rule))

--- a/cli/src/plugins/WindsurfOutputPlugin.projectConfig.test.ts
+++ b/cli/src/plugins/WindsurfOutputPlugin.projectConfig.test.ts
@@ -123,30 +123,6 @@ describe('windsurfOutputPlugin - projectConfig filtering', () => {
       expect(fileNames).toContain('rule-test-rule2.md')
     })
 
-    it('should expand include with subSeries', async () => {
-      const rules = [
-        createMockRulePrompt('test', 'rule1', 'uniapp', 'project'),
-        createMockRulePrompt('test', 'rule2', 'uniapp3', 'project'),
-        createMockRulePrompt('test', 'rule3', 'vue', 'project')
-      ]
-      const projects = [
-        createMockProject('proj1', tempDir, 'proj1', {
-          rules: {
-            include: ['uniapp'],
-            subSeries: {uniapp: ['uniapp3']}
-          }
-        })
-      ]
-      const ctx = createMockContext(tempDir, rules, projects)
-
-      const results = await plugin.registerProjectOutputFiles(ctx)
-      const fileNames = collectFileNames(results)
-
-      expect(fileNames).toContain('rule-test-rule1.md')
-      expect(fileNames).toContain('rule-test-rule2.md')
-      expect(fileNames).not.toContain('rule-test-rule3.md')
-    })
-
     it('should include rules without seriName regardless of include filter', async () => {
       const rules = [
         createMockRulePrompt('test', 'rule1', void 0, 'project'),

--- a/cli/src/plugins/WindsurfOutputPlugin.ts
+++ b/cli/src/plugins/WindsurfOutputPlugin.ts
@@ -13,7 +13,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import {buildMarkdownWithFrontMatter} from '@truenine/md-compiler/markdown'
 import {FilePathKind} from '@/types'
-import {filterRulesByProjectConfig} from '@/utils/ruleFilter'
+import {applySubSeriesGlobPrefix, filterRulesByProjectConfig} from '@/utils/ruleFilter'
 import {AbstractOutputPlugin} from './AbstractOutputPlugin'
 
 const CODEIUM_WINDSURF_DIR = '.codeium/windsurf'
@@ -225,8 +225,11 @@ export class WindsurfOutputPlugin extends AbstractOutputPlugin {
     for (const project of workspace.projects) {
       const projectDir = project.dirFromWorkspacePath
       if (projectDir == null) continue
-      const projectRules = filterRulesByProjectConfig(
-        rules.filter(r => r.scope === 'project'),
+      const projectRules = applySubSeriesGlobPrefix(
+        filterRulesByProjectConfig(
+          rules.filter(r => r.scope === 'project'),
+          project.projectConfig
+        ),
         project.projectConfig
       )
       if (projectRules.length === 0) continue
@@ -250,8 +253,11 @@ export class WindsurfOutputPlugin extends AbstractOutputPlugin {
       for (const project of workspace.projects) {
         const projectDir = project.dirFromWorkspacePath
         if (projectDir == null) continue
-        const projectRules = filterRulesByProjectConfig(
-          rules.filter(r => r.scope === 'project'),
+        const projectRules = applySubSeriesGlobPrefix(
+          filterRulesByProjectConfig(
+            rules.filter(r => r.scope === 'project'),
+            project.projectConfig
+          ),
           project.projectConfig
         )
         for (const rule of projectRules) {
@@ -280,8 +286,11 @@ export class WindsurfOutputPlugin extends AbstractOutputPlugin {
       for (const project of workspace.projects) {
         const projectDir = project.dirFromWorkspacePath
         if (projectDir == null) continue
-        const projectRules = filterRulesByProjectConfig(
-          rules.filter(r => r.scope === 'project'),
+        const projectRules = applySubSeriesGlobPrefix(
+          filterRulesByProjectConfig(
+            rules.filter(r => r.scope === 'project'),
+            project.projectConfig
+          ),
           project.projectConfig
         )
         if (projectRules.length === 0) continue

--- a/cli/src/utils/ruleFilter.property.test.ts
+++ b/cli/src/utils/ruleFilter.property.test.ts
@@ -3,9 +3,9 @@ import type {RulePrompt} from '@/types/InputTypes'
 import * as fc from 'fast-check'
 import {describe, expect, it} from 'vitest'
 import {FilePathKind, PromptKind} from '@/types'
-import {expandWithSubSeries, filterRulesByProjectConfig} from './ruleFilter'
+import {applySubSeriesGlobPrefix, filterRulesByProjectConfig} from './ruleFilter'
 
-function createMockRulePrompt(seriName: string | undefined): RulePrompt {
+function createMockRulePrompt(seriName: string | undefined, globs: readonly string[] = ['**/*.ts']): RulePrompt {
   const content = '# Rule body'
   return {
     type: PromptKind.Rule,
@@ -14,10 +14,10 @@ function createMockRulePrompt(seriName: string | undefined): RulePrompt {
     filePathKind: FilePathKind.Relative,
     dir: {pathKind: FilePathKind.Relative, path: '.', basePath: '', getDirectoryName: () => '.', getAbsolutePath: () => '.'},
     markdownContents: [],
-    yamlFrontMatter: {description: 'Test rule', globs: ['**/*.ts']},
+    yamlFrontMatter: {description: 'Test rule', globs: [...globs]},
     series: 'test',
     ruleName: 'test-rule',
-    globs: ['**/*.ts'],
+    globs: [...globs],
     scope: 'project',
     seriName
   }
@@ -25,60 +25,17 @@ function createMockRulePrompt(seriName: string | undefined): RulePrompt {
 
 const seriNameGen = fc.stringMatching(/^[a-z0-9]{1,20}$/)
 const seriNameArrayGen = fc.array(seriNameGen, {minLength: 0, maxLength: 10})
+const globGen = fc.stringMatching(/^\*\*\/\*\.[a-z]{1,5}$/)
+const globArrayGen = fc.array(globGen, {minLength: 1, maxLength: 5})
 
-const subSeriesGen = fc.dictionary(seriNameGen, seriNameArrayGen) // Generator for subSeries: Record<string, readonly string[]>
-
-describe('expandWithSubSeries property tests', () => {
-  it('should always include all input names in result', () => {
-    fc.assert(
-      fc.property(seriNameArrayGen, subSeriesGen, (names, subSeries) => {
-        const result = expandWithSubSeries(names, subSeries)
-        for (const name of names) expect(result).toContain(name)
-      }),
-      {numRuns: 100}
-    )
-  })
-
-  it('should never produce duplicates', () => {
-    fc.assert(
-      fc.property(seriNameArrayGen, subSeriesGen, (names, subSeries) => {
-        const result = expandWithSubSeries(names, subSeries)
-        const uniqueResult = [...new Set(result)]
-        expect(result).toHaveLength(uniqueResult.length)
-      }),
-      {numRuns: 100}
-    )
-  })
-
-  it('should be idempotent when subSeries has no matching keys', () => {
-    fc.assert(
-      fc.property(seriNameArrayGen, names => {
-        const emptySubSeries: Record<string, readonly string[]> = {}
-        const result1 = expandWithSubSeries(names, emptySubSeries)
-        const result2 = expandWithSubSeries(result1, emptySubSeries)
-        expect(result1).toEqual(result2)
-      }),
-      {numRuns: 100}
-    )
-  })
-
-  it('should expand result size >= unique input size', () => {
-    fc.assert(
-      fc.property(seriNameArrayGen, subSeriesGen, (names, subSeries) => {
-        const result = expandWithSubSeries(names, subSeries)
-        const uniqueNames = [...new Set(names)]
-        expect(result.length).toBeGreaterThanOrEqual(uniqueNames.length)
-      }),
-      {numRuns: 100}
-    )
-  })
-})
+const subdirGen = fc.stringMatching(/^[a-z][a-z0-9/-]{0,30}$/)
+const subSeriesGen = fc.dictionary(subdirGen, seriNameArrayGen)
 
 describe('filterRulesByProjectConfig property tests', () => {
   it('should return all rules when projectConfig is undefined', async () => {
     await fc.assert(
       fc.asyncProperty(seriNameArrayGen, async seriNames => {
-        const rules = seriNames.map(createMockRulePrompt)
+        const rules = seriNames.map(name => createMockRulePrompt(name))
         const result = filterRulesByProjectConfig(rules, void 0)
         expect(result).toHaveLength(rules.length)
       }),
@@ -93,7 +50,7 @@ describe('filterRulesByProjectConfig property tests', () => {
         seriNameArrayGen,
         seriNameArrayGen,
         async (ruleNames, includeNames, excludeNames) => {
-          const rules = ruleNames.map(createMockRulePrompt)
+          const rules = ruleNames.map(name => createMockRulePrompt(name))
           const projectConfig: ProjectConfig = {
             rules: {include: includeNames, exclude: excludeNames}
           }
@@ -112,7 +69,7 @@ describe('filterRulesByProjectConfig property tests', () => {
         seriNameArrayGen,
         seriNameArrayGen,
         async (ruleNames, includeNames) => {
-          const rules = ruleNames.map(createMockRulePrompt)
+          const rules = ruleNames.map(name => createMockRulePrompt(name))
           const projectConfig: ProjectConfig = {
             rules: {include: includeNames}
           }
@@ -130,7 +87,7 @@ describe('filterRulesByProjectConfig property tests', () => {
         seriNameArrayGen,
         seriNameArrayGen,
         async (ruleNames, excludeNames) => {
-          const rules = ruleNames.map(createMockRulePrompt)
+          const rules = ruleNames.map(name => createMockRulePrompt(name))
           const projectConfig: ProjectConfig = {
             rules: {exclude: excludeNames}
           }
@@ -153,7 +110,7 @@ describe('filterRulesByProjectConfig property tests', () => {
         seriNameArrayGen,
         async (definedNames, includeNames, excludeNames) => {
           const rules = [
-            ...definedNames.map(createMockRulePrompt),
+            ...definedNames.map(name => createMockRulePrompt(name)),
             createMockRulePrompt(void 0)
           ]
           const projectConfig: ProjectConfig = {
@@ -167,24 +124,130 @@ describe('filterRulesByProjectConfig property tests', () => {
       {numRuns: 100}
     )
   })
+})
 
-  it('subSeries expansion should include parent and children', async () => {
-    const parentGen = seriNameGen
-    const childrenGen = fc.array(seriNameGen, {minLength: 1, maxLength: 5})
-
+describe('applySubSeriesGlobPrefix property tests', () => {
+  it('should return original rules when no projectConfig', async () => {
     await fc.assert(
-      fc.asyncProperty(parentGen, childrenGen, async (parent, children) => {
-        const rules = [parent, ...children].map(createMockRulePrompt)
-        const projectConfig: ProjectConfig = {
-          rules: {
-            include: [parent],
-            subSeries: {[parent]: children}
+      fc.asyncProperty(
+        seriNameGen,
+        globArrayGen,
+        async (seriName, globs) => {
+          const rules = [createMockRulePrompt(seriName, globs)]
+          const result = applySubSeriesGlobPrefix(rules, void 0)
+          expect(result).toEqual(rules)
+        }
+      ),
+      {numRuns: 100}
+    )
+  })
+
+  it('should return original rules when no subSeries', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        seriNameGen,
+        globArrayGen,
+        async (seriName, globs) => {
+          const rules = [createMockRulePrompt(seriName, globs)]
+          const projectConfig: ProjectConfig = {rules: {include: [seriName]}}
+          const result = applySubSeriesGlobPrefix(rules, projectConfig)
+          expect(result).toEqual(rules)
+        }
+      ),
+      {numRuns: 100}
+    )
+  })
+
+  it('should not modify rules with undefined seriName', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        globArrayGen,
+        subSeriesGen,
+        async (globs, subSeries) => {
+          const rules = [createMockRulePrompt(void 0, globs)]
+          const projectConfig: ProjectConfig = {rules: {subSeries}}
+          const result = applySubSeriesGlobPrefix(rules, projectConfig)
+          expect(result[0].globs).toEqual(globs)
+        }
+      ),
+      {numRuns: 100}
+    )
+  })
+
+  it('should always produce valid glob patterns', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        seriNameGen,
+        globArrayGen,
+        subdirGen,
+        async (seriName, globs, subdir) => {
+          const rules = [createMockRulePrompt(seriName, globs)]
+          const projectConfig: ProjectConfig = {
+            rules: {subSeries: {[subdir]: [seriName]}}
+          }
+          const result = applySubSeriesGlobPrefix(rules, projectConfig)
+          for (const glob of result[0].globs) {
+            expect(typeof glob).toBe('string')
+            expect(glob.length).toBeGreaterThan(0)
           }
         }
-        const result = filterRulesByProjectConfig(rules, projectConfig)
-        expect(result.map(r => r.seriName)).toContain(parent)
-        for (const child of children) expect(result.map(r => r.seriName)).toContain(child)
-      }),
+      ),
+      {numRuns: 100}
+    )
+  })
+
+  it('should produce same number or more globs when matched', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        seriNameGen,
+        globArrayGen,
+        fc.array(subdirGen, {minLength: 1, maxLength: 5}),
+        async (seriName, globs, subdirs) => {
+          const rules = [createMockRulePrompt(seriName, globs)]
+          const subSeries: Record<string, readonly string[]> = {}
+          for (const subdir of subdirs) {
+            subSeries[subdir] = [seriName]
+          }
+          const projectConfig: ProjectConfig = {rules: {subSeries}}
+          const result = applySubSeriesGlobPrefix(rules, projectConfig)
+          expect(result[0].globs.length).toBeGreaterThanOrEqual(globs.length)
+        }
+      ),
+      {numRuns: 100}
+    )
+  })
+
+  it('should be deterministic', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        seriNameGen,
+        globArrayGen,
+        subSeriesGen,
+        async (seriName, globs, subSeries) => {
+          const rules = [createMockRulePrompt(seriName, globs)]
+          const projectConfig: ProjectConfig = {rules: {subSeries}}
+          const result1 = applySubSeriesGlobPrefix(rules, projectConfig)
+          const result2 = applySubSeriesGlobPrefix(rules, projectConfig)
+          expect(result1).toEqual(result2)
+        }
+      ),
+      {numRuns: 100}
+    )
+  })
+
+  it('should preserve rule count', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(seriNameGen, {minLength: 0, maxLength: 10}),
+        globArrayGen,
+        subSeriesGen,
+        async (seriNames, globs, subSeries) => {
+          const rules = seriNames.map(name => createMockRulePrompt(name, globs))
+          const projectConfig: ProjectConfig = {rules: {subSeries}}
+          const result = applySubSeriesGlobPrefix(rules, projectConfig)
+          expect(result).toHaveLength(rules.length)
+        }
+      ),
       {numRuns: 100}
     )
   })

--- a/cli/src/utils/ruleFilter.test.ts
+++ b/cli/src/utils/ruleFilter.test.ts
@@ -2,9 +2,9 @@ import type {ProjectConfig} from '@/types/ConfigTypes'
 import type {RulePrompt} from '@/types/InputTypes'
 import {describe, expect, it} from 'vitest'
 import {FilePathKind, PromptKind} from '@/types'
-import {expandWithSubSeries, filterRulesByProjectConfig} from './ruleFilter'
+import {applySubSeriesGlobPrefix, filterRulesByProjectConfig} from './ruleFilter'
 
-function createMockRulePrompt(seriName: string | undefined): RulePrompt {
+function createMockRulePrompt(seriName: string | undefined, globs: readonly string[] = ['**/*.ts']): RulePrompt {
   const content = '# Rule body'
   return {
     type: PromptKind.Rule,
@@ -13,49 +13,14 @@ function createMockRulePrompt(seriName: string | undefined): RulePrompt {
     filePathKind: FilePathKind.Relative,
     dir: {pathKind: FilePathKind.Relative, path: '.', basePath: '', getDirectoryName: () => '.', getAbsolutePath: () => '.'},
     markdownContents: [],
-    yamlFrontMatter: {description: 'Test rule', globs: ['**/*.ts']},
+    yamlFrontMatter: {description: 'Test rule', globs: [...globs]},
     series: 'test',
     ruleName: 'test-rule',
-    globs: ['**/*.ts'],
+    globs: [...globs],
     scope: 'project',
     seriName
   }
 }
-
-describe('expandWithSubSeries', () => {
-  it('should return same array when no subSeries match', () => {
-    const result = expandWithSubSeries(['uniapp'], {vue: ['vue2', 'vue3']})
-    expect(result).toEqual(['uniapp'])
-  })
-
-  it('should expand single name with children', () => {
-    const result = expandWithSubSeries(['uniapp'], {uniapp: ['uniapp2', 'uniapp3']})
-    expect(result).toEqual(['uniapp', 'uniapp2', 'uniapp3'])
-  })
-
-  it('should expand multiple names', () => {
-    const result = expandWithSubSeries(['uniapp', 'vue'], {
-      uniapp: ['uniapp2'],
-      vue: ['vue2', 'vue3']
-    })
-    expect(result).toEqual(['uniapp', 'vue', 'uniapp2', 'vue2', 'vue3'])
-  })
-
-  it('should deduplicate expanded names', () => {
-    const result = expandWithSubSeries(['uniapp', 'uniapp'], {uniapp: ['uniapp2', 'uniapp']})
-    expect(result).toEqual(['uniapp', 'uniapp2'])
-  })
-
-  it('should handle empty subSeries', () => {
-    const result = expandWithSubSeries(['uniapp'], {})
-    expect(result).toEqual(['uniapp'])
-  })
-
-  it('should handle empty names array', () => {
-    const result = expandWithSubSeries([], {uniapp: ['uniapp2']})
-    expect(result).toEqual([])
-  })
-})
 
 describe('filterRulesByProjectConfig', () => {
   it('should return all rules when no projectConfig', () => {
@@ -154,65 +119,6 @@ describe('filterRulesByProjectConfig', () => {
     })
   })
 
-  describe('subSeries expansion', () => {
-    it('should expand include with subSeries', () => {
-      const rules = [
-        createMockRulePrompt('uniapp'),
-        createMockRulePrompt('uniapp3'),
-        createMockRulePrompt('vue')
-      ]
-      const projectConfig: ProjectConfig = {
-        rules: {
-          include: ['uniapp'],
-          subSeries: {uniapp: ['uniapp2', 'uniapp3']}
-        }
-      }
-      const result = filterRulesByProjectConfig(rules, projectConfig)
-      expect(result).toHaveLength(2)
-      expect(result.map(r => r.seriName)).toContain('uniapp')
-      expect(result.map(r => r.seriName)).toContain('uniapp3')
-    })
-
-    it('should expand exclude with subSeries', () => {
-      const rules = [
-        createMockRulePrompt('uniapp'),
-        createMockRulePrompt('uniapp3'),
-        createMockRulePrompt('vue')
-      ]
-      const projectConfig: ProjectConfig = {
-        rules: {
-          exclude: ['uniapp'],
-          subSeries: {uniapp: ['uniapp3']}
-        }
-      }
-      const result = filterRulesByProjectConfig(rules, projectConfig)
-      expect(result).toHaveLength(1)
-      expect(result[0].seriName).toBe('vue')
-    })
-
-    it('should expand both include and exclude', () => {
-      const rules = [
-        createMockRulePrompt('uniapp'),
-        createMockRulePrompt('uniapp2'),
-        createMockRulePrompt('uniapp3'),
-        createMockRulePrompt('vue')
-      ]
-      const projectConfig: ProjectConfig = {
-        rules: {
-          include: ['uniapp'],
-          exclude: ['uniapp2'],
-          subSeries: {
-            uniapp: ['uniapp2', 'uniapp3']
-          }
-        }
-      }
-      const result = filterRulesByProjectConfig(rules, projectConfig)
-      expect(result).toHaveLength(2)
-      expect(result.map(r => r.seriName)).toContain('uniapp')
-      expect(result.map(r => r.seriName)).toContain('uniapp3')
-    })
-  })
-
   describe('edge cases', () => {
     it('should handle empty rules array', () => {
       const projectConfig: ProjectConfig = {rules: {include: ['uniapp']}}
@@ -228,17 +134,179 @@ describe('filterRulesByProjectConfig', () => {
       const result = filterRulesByProjectConfig(rules, projectConfig)
       expect(result).toHaveLength(0)
     })
+  })
+})
 
-    it('should handle subSeries not matching any include', () => {
-      const rules = [createMockRulePrompt('uniapp'), createMockRulePrompt('vue')]
+describe('applySubSeriesGlobPrefix', () => {
+  describe('basic functionality', () => {
+    it('should return original rules when no projectConfig', () => {
+      const rules = [createMockRulePrompt('uniapp')]
+      const result = applySubSeriesGlobPrefix(rules, void 0)
+      expect(result).toEqual(rules)
+    })
+
+    it('should return original rules when no subSeries config', () => {
+      const rules = [createMockRulePrompt('uniapp')]
+      const projectConfig: ProjectConfig = {rules: {include: ['uniapp']}}
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result).toEqual(rules)
+    })
+
+    it('should return original rules when empty subSeries', () => {
+      const rules = [createMockRulePrompt('uniapp')]
+      const projectConfig: ProjectConfig = {rules: {subSeries: {}}}
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result).toEqual(rules)
+    })
+
+    it('should return original rules when seriName is undefined', () => {
+      const rules = [createMockRulePrompt(void 0)]
       const projectConfig: ProjectConfig = {
-        rules: {
-          include: ['react'],
-          subSeries: {react: ['react-native']}
-        }
+        rules: {subSeries: {applet: ['uniapp3']}}
       }
-      const result = filterRulesByProjectConfig(rules, projectConfig)
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result).toEqual(rules)
+    })
+  })
+
+  describe('glob prefix addition', () => {
+    it('should add prefix to globs when seriName matches', () => {
+      const rules = [createMockRulePrompt('uniapp3', ['**/*.vue'])]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {applet: ['uniapp3']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['applet/**/*.vue'])
+    })
+
+    it('should add prefix to multiple globs', () => {
+      const rules = [createMockRulePrompt('uniapp3', ['**/*.vue', '**/*.ts'])]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {applet: ['uniapp3']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['applet/**/*.vue', 'applet/**/*.ts'])
+    })
+
+    it('should add multiple prefixes when seriName matches multiple subdirs', () => {
+      const rules = [createMockRulePrompt('uniapp3', ['**/*.vue'])]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {applet: ['uniapp3'], example_applet: ['uniapp3']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['applet/**/*.vue', 'example_applet/**/*.vue'])
+    })
+
+    it('should return original rule when seriName does not match', () => {
+      const rules = [createMockRulePrompt('vue', ['**/*.vue'])]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {applet: ['uniapp3']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['**/*.vue'])
+    })
+  })
+
+  describe('glob format handling', () => {
+    it('should handle globs starting with **/', () => {
+      const rules = [createMockRulePrompt('uniapp3', ['**/*.vue'])]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {applet: ['uniapp3']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['applet/**/*.vue'])
+    })
+
+    it('should convert globs starting with * to **/ format', () => {
+      const rules = [createMockRulePrompt('uniapp3', ['*.vue'])]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {applet: ['uniapp3']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['applet/**/*.vue'])
+    })
+
+    it('should handle globs with path prefix', () => {
+      const rules = [createMockRulePrompt('uniapp3', ['src/**/*.ts'])]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {applet: ['uniapp3']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['applet/src/**/*.ts'])
+    })
+  })
+
+  describe('duplicate prefix prevention', () => {
+    it('should skip adding prefix when glob already has it', () => {
+      const rules = [createMockRulePrompt('uniapp3', ['applet/**/*.vue'])]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {applet: ['uniapp3']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['applet/**/*.vue'])
+    })
+
+    it('should add only missing prefix when multiple subdirs configured', () => {
+      const rules = [createMockRulePrompt('uniapp3', ['applet/**/*.vue'])]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {applet: ['uniapp3'], example_applet: ['uniapp3']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['applet/**/*.vue', 'example_applet/**/*.vue'])
+    })
+  })
+
+  describe('subdir path normalization', () => {
+    it('should normalize subdir path with trailing slash', () => {
+      const rules = [createMockRulePrompt('uniapp3', ['**/*.vue'])]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {'applet/': ['uniapp3']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['applet/**/*.vue'])
+    })
+
+    it('should normalize subdir path with ./ prefix', () => {
+      const rules = [createMockRulePrompt('uniapp3', ['**/*.vue'])]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {'./applet': ['uniapp3']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['applet/**/*.vue'])
+    })
+
+    it('should handle nested subdir paths', () => {
+      const rules = [createMockRulePrompt('vue', ['**/*.vue'])]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {'frontend/apps': ['vue']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['frontend/apps/**/*.vue'])
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty rules array', () => {
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {applet: ['uniapp3']}}
+      }
+      const result = applySubSeriesGlobPrefix([], projectConfig)
       expect(result).toHaveLength(0)
+    })
+
+    it('should handle multiple rules with different seriNames', () => {
+      const rules = [
+        createMockRulePrompt('uniapp3', ['**/*.vue']),
+        createMockRulePrompt('vue', ['**/*.ts']),
+        createMockRulePrompt(void 0, ['**/*.js'])
+      ]
+      const projectConfig: ProjectConfig = {
+        rules: {subSeries: {applet: ['uniapp3'], example_applet: ['uniapp3', 'vue']}}
+      }
+      const result = applySubSeriesGlobPrefix(rules, projectConfig)
+      expect(result[0].globs).toEqual(['applet/**/*.vue', 'example_applet/**/*.vue'])
+      expect(result[1].globs).toEqual(['example_applet/**/*.ts'])
+      expect(result[2].globs).toEqual(['**/*.js'])
     })
   })
 })

--- a/cli/src/utils/ruleFilter.ts
+++ b/cli/src/utils/ruleFilter.ts
@@ -1,43 +1,78 @@
 import type {ProjectConfig} from '@/types/ConfigTypes'
 import type {RulePrompt} from '@/types/InputTypes'
 
-/**
- * Expand names with their subSeries definitions.
- * Each name in `names` is expanded to include its children from `subSeries`.
- * Expansion is only one level deep.
- */
-export function expandWithSubSeries(
-  names: readonly string[],
-  subSeries: Readonly<Record<string, readonly string[]>>
-): readonly string[] {
-  const result = new Set<string>(names)
-
-  for (const name of names) {
-    if (Object.hasOwn(subSeries, name)) { // (e.g., keys like "constructor" would access Object.prototype.constructor) // Use Object.prototype.hasOwnProperty to avoid prototype pollution
-      const children = subSeries[name]
-      if (children != null) {
-        for (const child of children) result.add(child)
-      }
-    }
-  }
-
-  return [...result]
+function normalizeSubdirPath(subdir: string): string {
+  let normalized = subdir.replaceAll(/\.\/+/g, '')
+  normalized = normalized.replaceAll(/\/+$/g, '')
+  return normalized
 }
 
-/**
- * Filter rules based on project configuration.
- *
- * Logic:
- * 1. If no projectConfig.rules exists, return all rules (backward compatible)
- * 2. Expand include/exclude with subSeries mappings
- * 3. Rules without seriName are always included (backward compatible)
- * 4. Apply include filter first (if exists)
- * 5. Apply exclude filter second (if exists)
- *
- * @param rules - Array of RulePrompt to filter
- * @param projectConfig - Project configuration containing rules config
- * @returns Filtered array of RulePrompt
- */
+function smartConcatGlob(prefix: string, glob: string): string {
+  if (glob.startsWith('**/')) return `${prefix}/${glob}`
+  if (glob.startsWith('*')) return `${prefix}/**/${glob}`
+  return `${prefix}/${glob}`
+}
+
+function extractPrefixAndBaseGlob(glob: string, prefixes: readonly string[]): {prefix: string | null, baseGlob: string} {
+  for (const prefix of prefixes) {
+    const normalizedPrefix = prefix.replaceAll(/\/+$/g, '')
+    const patterns = [
+      {prefix: normalizedPrefix, pattern: `${normalizedPrefix}/`},
+      {prefix: normalizedPrefix, pattern: `${normalizedPrefix}\\`}
+    ]
+    for (const {prefix: p, pattern} of patterns) {
+      if (glob.startsWith(pattern)) return {prefix: p, baseGlob: glob.slice(pattern.length)}
+    }
+    if (glob === normalizedPrefix) return {prefix: normalizedPrefix, baseGlob: '**/*'}
+  }
+  return {prefix: null, baseGlob: glob}
+}
+
+export function applySubSeriesGlobPrefix(
+  rules: readonly RulePrompt[],
+  projectConfig: ProjectConfig | undefined
+): readonly RulePrompt[] {
+  const subSeries = projectConfig?.rules?.subSeries
+  if (subSeries == null || Object.keys(subSeries).length === 0) return rules
+
+  const normalizedSubSeries: Record<string, readonly string[]> = {}
+  for (const [subdir, seriNames] of Object.entries(subSeries)) {
+    const normalizedSubdir = normalizeSubdirPath(subdir)
+    normalizedSubSeries[normalizedSubdir] = seriNames
+  }
+
+  const allPrefixes = Object.keys(normalizedSubSeries)
+
+  return rules.map(rule => {
+    if (rule.seriName == null) return rule
+
+    const matchedPrefixes: string[] = []
+    for (const [subdir, seriNames] of Object.entries(normalizedSubSeries)) {
+      if (seriNames.includes(rule.seriName)) matchedPrefixes.push(subdir)
+    }
+
+    if (matchedPrefixes.length === 0) return rule
+
+    const newGlobs: string[] = []
+    for (const originalGlob of rule.globs) {
+      const {prefix: existingPrefix, baseGlob} = extractPrefixAndBaseGlob(originalGlob, allPrefixes)
+
+      if (existingPrefix != null) newGlobs.push(originalGlob)
+
+      for (const prefix of matchedPrefixes) {
+        if (prefix === existingPrefix) continue
+        const newGlob = smartConcatGlob(prefix, baseGlob)
+        if (!newGlobs.includes(newGlob)) newGlobs.push(newGlob)
+      }
+    }
+
+    return {
+      ...rule,
+      globs: newGlobs
+    }
+  })
+}
+
 export function filterRulesByProjectConfig(
   rules: readonly RulePrompt[],
   projectConfig: ProjectConfig | undefined
@@ -45,25 +80,17 @@ export function filterRulesByProjectConfig(
   const rulesConfig = projectConfig?.rules
   if (rulesConfig == null) return rules
 
-  const {include, exclude, subSeries} = rulesConfig
-
-  let effectiveInclude = include // Expand include with subSeries
-  if (effectiveInclude != null && subSeries != null) effectiveInclude = expandWithSubSeries(effectiveInclude, subSeries)
-
-  let effectiveExclude = exclude // Expand exclude with subSeries
-  if (effectiveExclude != null && subSeries != null) effectiveExclude = expandWithSubSeries(effectiveExclude, subSeries)
+  const {include, exclude} = rulesConfig
 
   return rules.filter(rule => {
-    if (rule.seriName == null) { // seriName undefined → always output (backward compatible)
-      return true
+    if (rule.seriName == null) return true
+
+    if (include != null && include.length > 0) {
+      if (!include.includes(rule.seriName)) return false
     }
 
-    if (effectiveInclude != null && effectiveInclude.length > 0) { // Include filter
-      if (!effectiveInclude.includes(rule.seriName)) return false
-    }
-
-    if (effectiveExclude != null && effectiveExclude.length > 0) { // Exclude filter
-      if (effectiveExclude.includes(rule.seriName)) return false
+    if (exclude != null && exclude.length > 0) {
+      if (exclude.includes(rule.seriName)) return false
     }
 
     return true

--- a/doc/package.json
+++ b/doc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-docs",
   "private": true,
-  "version": "2026.10219.10305",
+  "version": "2026.10219.10518",
   "description": "Documentation site for @truenine/memory-sync, built with Next.js 16 and MDX.",
   "scripts": {
     "dev": "next dev",

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-gui",
-  "version": "2026.10219.10305",
+  "version": "2026.10219.10518",
   "private": true,
   "engines": {
     "node": ">=25.2.1",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-sync-gui"
-version = "2026.10219.10305"
+version = "2026.10219.10518"
 description = "Memory Sync desktop GUI application"
 authors = ["TrueNine"]
 edition = "2021"

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "version": "2026.10219.10305",
+  "version": "2026.10219.10518",
   "productName": "Memory Sync",
   "identifier": "org.truenine.memory-sync",
   "build": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync",
-  "version": "2026.10219.10305",
+  "version": "2026.10219.10518",
   "description": "Cross-AI-tool prompt synchronisation toolkit (CLI + Tauri desktop GUI) — one ruleset, multi-target adaptation. Monorepo powered by pnpm + Turbo.",
   "license": "AGPL-3.0-only",
   "keywords": [

--- a/packages/init-bundle/public/public/tnmsc.example.json
+++ b/packages/init-bundle/public/public/tnmsc.example.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026.10219.10305",
+  "version": "2026.10219.10518",
   "workspaceDir": "~/project",
   "shadowSourceProject": {
     "name": "tnmsc-shadow",


### PR DESCRIPTION
## Summary

- 重构 `subSeries` 语义：从规则系列扩展改为子目录前缀映射
- 新增 `applySubSeriesGlobPrefix` 函数，支持智能 glob 拼接和重复前缀检测
- 更新所有 OutputPlugin 以支持新的 subSeries 功能

## Changes

### 核心功能变更

`subSeries` 语义变更：

```jsonc
// 新语义：子目录前缀映射
{
  "rules": {
    "subSeries": {
      "applet": ["uniapp3"],           // uniapp3 规则的 globs 加 applet/ 前缀
      "example_applet": ["uniapp3"]    // uniapp3 规则的 globs 加 example_applet/ 前缀
    }
  }
}
```

### 修改的文件

| 文件 | 变更 |
|------|------|
| `cli/src/utils/ruleFilter.ts` | 删除 `expandWithSubSeries`，简化 `filterRulesByProjectConfig`，新增 `applySubSeriesGlobPrefix` |
| `cli/src/plugins/CursorOutputPlugin.ts` | 添加 `applySubSeriesGlobPrefix` 调用 |
| `cli/src/plugins/KiroCLIOutputPlugin.ts` | 添加 `applySubSeriesGlobPrefix` 调用 |
| `cli/src/plugins/ClaudeCodeCLIOutputPlugin.ts` | 添加 `applySubSeriesGlobPrefix` 调用 |
| `cli/src/plugins/WindsurfOutputPlugin.ts` | 添加 `applySubSeriesGlobPrefix` 调用 |
| 测试文件 | 更新所有 subSeries 相关测试 |

### 功能特性

- **智能 glob 转换**：`*.vue` → `{prefix}/**/*.vue`
- **重复前缀跳过**：glob 已有某前缀时保留原样，仅添加缺失的前缀
- **路径标准化**：自动处理 `./prefix` 和 `prefix/`
- **仅项目级规则**：全局规则不受影响

## Test plan

- [x] 单元测试：`ruleFilter.test.ts` 新增 `applySubSeriesGlobPrefix` 测试
- [x] 属性测试：`ruleFilter.property.test.ts` 新增属性测试
- [x] 集成测试：所有 OutputPlugin 的 projectConfig 测试已更新
- [x] 实际验证：在 wuzhiyuan-t0003 项目中验证 globs 前缀正确添加