### PR TITLE
fix: 修正 Windsurf 的 ignore 文件错误

### DIFF
--- a/cli/src/types/ShadowSourceProjectTypes.ts
+++ b/cli/src/types/ShadowSourceProjectTypes.ts
@@ -101,7 +101,8 @@ export const SHADOW_SOURCE_FILE_NAMES = {
   QODER_IGNORE: '.qoderignore', // AI Agent ignore files
   CURSOR_IGNORE: '.cursorignore',
   WARP_INDEX_IGNORE: '.warpindexignore',
-  AI_IGNORE: '.aiignore'
+  AI_IGNORE: '.aiignore',
+  CODEIUM_IGNORE: '.codeiumignore' // Windsurf ignore file
 } as const
 
 /**
@@ -272,6 +273,11 @@ export const DEFAULT_SHADOW_SOURCE_PROJECT_STRUCTURE: ShadowSourceProjectDirecto
       name: SHADOW_SOURCE_FILE_NAMES.AI_IGNORE,
       required: false,
       description: 'AI ignore file'
+    },
+    {
+      name: SHADOW_SOURCE_FILE_NAMES.CODEIUM_IGNORE,
+      required: false,
+      description: 'Windsurf ignore file'
     }
   ]
 } as const


### PR DESCRIPTION
## 问题描述

修正了 Windsurf 的 ignore 文件配置错误。之前在 \ShadowSourceProjectTypes.ts\ 中缺少了 \.codeiumignore\ 文件的定义，导致 Windsurf 输出插件无法正确识别和处理该文件。

## 修改内容

- 在 \SHADOW_SOURCE_FILE_NAMES\ 中添加了 \CODEIUM_IGNORE: '.codeiumignore'\ 常量定义
- 在 \DEFAULT_SHADOW_SOURCE_PROJECT_STRUCTURE.ignoreFiles\ 数组中添加了 Windsurf ignore 文件条目

## 相关文件

- \cli/src/types/ShadowSourceProjectTypes.ts\

## 说明

虽然 \AIAgentIgnoreConfigFileInputPlugin\ 和 \WindsurfOutputPlugin\ 已经支持 \.codeiumignore\ 文件，但在项目结构定义中缺少了该文件的声明，这可能导致结构验证和生成功能无法正确识别该文件。