### PR TITLE
ci: 更新 GitHub Actions 并发组和条件执行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,13 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.merged }}
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-24.04
+    if: github.event.pull_request.merged == false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,13 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.merged }}
   cancel-in-progress: true
 
 jobs:
   test:
     runs-on: ubuntu-24.04
+    if: github.event.pull_request.merged == false
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
修改 CI 和测试工作流的并发组命名规则，添加 PR 合并状态作为分组条件
增加工作流执行条件，仅在 PR 未合并时运行