### PR TITLE
ci: consolidate GUI platform builds into unified workflow

### DIFF
--- a/.github/workflows/build-gui-all.yml
+++ b/.github/workflows/build-gui-all.yml
@@ -1,0 +1,72 @@
+name: Build GUI All Platforms
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-all:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - os: windows-latest
+            platform: windows
+          - os: ubuntu-24.04
+            platform: linux
+          - os: macos-14
+            platform: macos
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node-pnpm
+      - uses: ./.github/actions/setup-tauri
+        with:
+          version: ${{ inputs.version }}
+
+      - name: Build GUI
+        working-directory: ./gui
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: pnpm tauri build
+
+      - name: Upload Windows artifacts
+        if: matrix.platform == 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: gui-${{ matrix.os }}
+          path: |
+            gui/src-tauri/target/*/release/bundle/**/*.exe
+            gui/src-tauri/target/release/bundle/**/*.exe
+          if-no-files-found: error
+
+      - name: Upload Linux artifacts
+        if: matrix.platform == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: gui-${{ matrix.os }}
+          path: |
+            gui/src-tauri/target/*/release/bundle/**/*.AppImage
+            gui/src-tauri/target/*/release/bundle/**/*.deb
+            gui/src-tauri/target/*/release/bundle/**/*.rpm
+            gui/src-tauri/target/release/bundle/**/*.AppImage
+            gui/src-tauri/target/release/bundle/**/*.deb
+            gui/src-tauri/target/release/bundle/**/*.rpm
+          if-no-files-found: error
+
+      - name: Upload macOS artifacts
+        if: matrix.platform == 'macos'
+        uses: actions/upload-artifact@v4
+        with:
+          name: gui-${{ matrix.os }}
+          path: |
+            gui/src-tauri/target/*/release/bundle/**/*.dmg
+            gui/src-tauri/target/release/bundle/**/*.dmg
+          if-no-files-found: error

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -269,34 +269,18 @@ jobs:
           path: ${{ matrix.archive }}
           if-no-files-found: error
 
-  # 6. 构建 GUI — 三平台并行
-  release-gui-win:
+  # 6. 构建 GUI — 三平台并行（fail-fast: 任一失败则全部取消）
+  build-gui-all:
     needs: [check-gui-version]
     if: needs.check-gui-version.outputs.should_release == 'true'
-    uses: ./.github/workflows/release-gui-win.yml
-    with:
-      version: ${{ needs.check-gui-version.outputs.version }}
-    secrets: inherit
-
-  release-gui-linux:
-    needs: [check-gui-version]
-    if: needs.check-gui-version.outputs.should_release == 'true'
-    uses: ./.github/workflows/release-gui-linux.yml
-    with:
-      version: ${{ needs.check-gui-version.outputs.version }}
-    secrets: inherit
-
-  release-gui-macos:
-    needs: [check-gui-version]
-    if: needs.check-gui-version.outputs.should_release == 'true'
-    uses: ./.github/workflows/release-gui-macos.yml
+    uses: ./.github/workflows/build-gui-all.yml
     with:
       version: ${{ needs.check-gui-version.outputs.version }}
     secrets: inherit
 
   # 7. 收集三平台产物，创建 GitHub Release + tag
   release-gui-collect:
-    needs: [check-gui-version, release-gui-win, release-gui-linux, release-gui-macos]
+    needs: [check-gui-version, build-gui-all]
     if: needs.check-gui-version.outputs.should_release == 'true'
     uses: ./.github/workflows/release-gui-collect.yml
     with:


### PR DESCRIPTION
- Create new build-gui-all.yml workflow that builds GUI for Windows, Linux, and macOS in parallel
- Replace three separate platform-specific workflows (release-gui-win, release-gui-linux, release-gui-macos) with single unified workflow call
- Configure fail-fast strategy to cancel all builds if any platform fails
- Update release-cli.yml to call consolidated build-gui-all workflow instead of three individual workflows
- Simplify job dependencies by consolidating three separate needs into single build-gui-all job
- Reduces workflow maintenance overhead and improves consistency across platform builds