### PR TITLE
ci(setup-tauri): add Linux dependency installation step

### DIFF
--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -13,6 +13,18 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install Linux dependencies
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libwebkit2gtk-4.1-dev \
+          libappindicator3-dev \
+          librsvg2-dev \
+          patchelf \
+          libssl-dev
+
     - name: Install Rust stable
       uses: dtolnay/rust-toolchain@stable
       with:


### PR DESCRIPTION
- Install required Linux development packages for Tauri builds
- Add libwebkit2gtk-4.1-dev for WebKit support
- Add libappindicator3-dev for system tray functionality
- Add librsvg2-dev for SVG rendering
- Add patchelf for binary patching
- Add libssl-dev for SSL/TLS support
- Run apt-get update before package installation to ensure latest package lists
- Conditional execution only on Linux runners to avoid unnecessary steps on other platforms