### PR TITLE
fix: sanitize tauri signing key for gui release

### DIFF
--- a/.githooks/sync-versions.ts
+++ b/.githooks/sync-versions.ts
@@ -28,7 +28,15 @@ function getCatalogVersion(pkgName: string): string | null {
 }
 
 const eslintConfigVersion = getCatalogVersion('@truenine/eslint10-config')
-const rootPkg: PackageJson = JSON.parse(readFileSync(resolve('package.json'), 'utf-8'))
+const rootPackagePath = resolve('package.json')
+const requestedVersion = process.argv[2]?.trim()
+const rootPkg: PackageJson = JSON.parse(readFileSync(rootPackagePath, 'utf-8'))
+
+if (requestedVersion && rootPkg.version !== requestedVersion) {
+  rootPkg.version = requestedVersion
+  writeFileSync(rootPackagePath, JSON.stringify(rootPkg, null, 2) + '\n', 'utf-8')
+}
+
 const rootVersion = rootPkg.version
 
 if (!rootVersion) {

--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Rust targets to install (comma-separated)
     required: false
     default: ''
+  signing-private-key:
+    description: Tauri updater signing private key content
+    required: false
+    default: ''
   version:
     description: Version string to sync into Cargo.toml and tauri.conf.json
     required: true
@@ -41,6 +45,17 @@ runs:
       uses: dtolnay/rust-toolchain@stable
       with:
         targets: ${{ inputs.rust-targets }}
+
+    - name: Normalize Tauri signing key
+      if: ${{ inputs.signing-private-key != '' }}
+      shell: pwsh
+      env:
+        RAW_TAURI_SIGNING_PRIVATE_KEY: ${{ inputs.signing-private-key }}
+      run: |
+        $normalized = $env:RAW_TAURI_SIGNING_PRIVATE_KEY.TrimStart([char]0xFEFF)
+        "TAURI_SIGNING_PRIVATE_KEY<<EOF" >> $env:GITHUB_ENV
+        $normalized >> $env:GITHUB_ENV
+        "EOF" >> $env:GITHUB_ENV
 
     - name: Get Cargo deps hash (exclude root package version for stable cache key)
       id: cargo-deps-hash

--- a/.github/workflows/build-gui-all.yml
+++ b/.github/workflows/build-gui-all.yml
@@ -35,12 +35,12 @@ jobs:
       - uses: ./.github/actions/setup-tauri
         with:
           rust-targets: ${{ matrix.rust-targets }}
+          signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           version: ${{ inputs.version }}
 
       - name: Build GUI
         working-directory: ./gui
         env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: ${{ matrix.tauri-command }}
 

--- a/.github/workflows/release-gui-linux.yml
+++ b/.github/workflows/release-gui-linux.yml
@@ -21,12 +21,12 @@ jobs:
 
       - uses: ./.github/actions/setup-tauri
         with:
+          signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           version: ${{ inputs.version }}
 
       - name: Build GUI
         working-directory: ./gui
         env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: pnpm tauri build
 

--- a/.github/workflows/release-gui-macos.yml
+++ b/.github/workflows/release-gui-macos.yml
@@ -21,12 +21,12 @@ jobs:
       - uses: ./.github/actions/setup-tauri
         with:
           rust-targets: aarch64-apple-darwin,x86_64-apple-darwin
+          signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           version: ${{ inputs.version }}
 
       - name: Build GUI
         working-directory: ./gui
         env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: pnpm tauri build --target universal-apple-darwin
 

--- a/.github/workflows/release-gui-win.yml
+++ b/.github/workflows/release-gui-win.yml
@@ -20,12 +20,12 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
       - uses: ./.github/actions/setup-tauri
         with:
+          signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           version: ${{ inputs.version }}
 
       - name: Build GUI
         working-directory: ./gui
         env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: pnpm tauri build
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.10314.10606"
+version = "2026.10314.10703"
 edition = "2024"
 license = "AGPL-3.0-only"
 authors = ["TrueNine"]

--- a/cli/npm/darwin-arm64/package.json
+++ b/cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-darwin-arm64",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "os": [
     "darwin"
   ],

--- a/cli/npm/darwin-x64/package.json
+++ b/cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-darwin-x64",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "os": [
     "darwin"
   ],

--- a/cli/npm/linux-arm64-gnu/package.json
+++ b/cli/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-linux-arm64-gnu",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "os": [
     "linux"
   ],

--- a/cli/npm/linux-x64-gnu/package.json
+++ b/cli/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-linux-x64-gnu",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "os": [
     "linux"
   ],

--- a/cli/npm/win32-x64-msvc/package.json
+++ b/cli/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-win32-x64-msvc",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "os": [
     "win32"
   ],

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-cli",
   "type": "module",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "description": "TrueNine Memory Synchronization CLI",
   "author": "TrueNine",
   "license": "AGPL-3.0-only",

--- a/doc/package.json
+++ b/doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-docs",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "private": true,
   "description": "Documentation site for @truenine/memory-sync, built with Next.js 16 and MDX.",
   "engines": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-gui",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "private": true,
   "engines": {
     "node": ">=25.2.1",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-sync-gui"
-version = "2026.10314.10606"
+version = "2026.10314.10703"
 description = "Memory Sync desktop GUI application"
 authors.workspace = true
 edition.workspace = true

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "productName": "Memory Sync",
   "identifier": "org.truenine.memory-sync",
   "build": {

--- a/libraries/logger/package.json
+++ b/libraries/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/logger",
   "type": "module",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "private": true,
   "description": "Rust-powered structured logger for Node.js via N-API",
   "license": "AGPL-3.0-only",

--- a/libraries/md-compiler/package.json
+++ b/libraries/md-compiler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/md-compiler",
   "type": "module",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "private": true,
   "description": "Rust-powered MDX→Markdown compiler for Node.js with pure-TS fallback",
   "license": "AGPL-3.0-only",

--- a/libraries/script-runtime/package.json
+++ b/libraries/script-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/script-runtime",
   "type": "module",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "private": true,
   "description": "Rust-backed TypeScript proxy runtime for tnmsc",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync",
-  "version": "2026.10314.10606",
+  "version": "2026.10314.10703",
   "description": "Cross-AI-tool prompt synchronisation toolkit (CLI + Tauri desktop GUI) — one ruleset, multi-target adaptation. Monorepo powered by pnpm + Turbo.",
   "license": "AGPL-3.0-only",
   "keywords": [


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM from the Tauri signing key before GUI builds consume it
- route all GUI build and debug workflows through the same key normalization path
- bump workspace versions to 2026.10314.10703 after the partially published 2026.10314.10606 run

## Validation
- pnpm exec tsx .githooks/sync-versions.ts 2026.10314.10703
- workflow static contract check
- prior local build/test suite from the 2026.10314.10606 release prep remained green