### PR TITLE
fix: normalize tauri signing password

### DIFF
--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Tauri updater signing private key content
     required: false
     default: ''
+  signing-private-key-password:
+    description: Tauri updater signing private key password
+    required: false
+    default: ''
   version:
     description: Version string to sync into Cargo.toml and tauri.conf.json
     required: true
@@ -54,6 +58,17 @@ runs:
       run: |
         $normalized = $env:RAW_TAURI_SIGNING_PRIVATE_KEY.TrimStart([char]0xFEFF)
         "TAURI_SIGNING_PRIVATE_KEY<<EOF" >> $env:GITHUB_ENV
+        $normalized >> $env:GITHUB_ENV
+        "EOF" >> $env:GITHUB_ENV
+
+    - name: Normalize Tauri signing key password
+      if: ${{ inputs.signing-private-key-password != '' }}
+      shell: pwsh
+      env:
+        RAW_TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ inputs.signing-private-key-password }}
+      run: |
+        $normalized = $env:RAW_TAURI_SIGNING_PRIVATE_KEY_PASSWORD.TrimStart([char]0xFEFF).TrimEnd("`r", "`n")
+        "TAURI_SIGNING_PRIVATE_KEY_PASSWORD<<EOF" >> $env:GITHUB_ENV
         $normalized >> $env:GITHUB_ENV
         "EOF" >> $env:GITHUB_ENV
 

--- a/.github/workflows/build-gui-all.yml
+++ b/.github/workflows/build-gui-all.yml
@@ -36,12 +36,11 @@ jobs:
         with:
           rust-targets: ${{ matrix.rust-targets }}
           signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          signing-private-key-password: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           version: ${{ inputs.version }}
 
       - name: Build GUI
         working-directory: ./gui
-        env:
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: ${{ matrix.tauri-command }}
 
       - name: Upload Windows artifacts

--- a/.github/workflows/release-gui-linux.yml
+++ b/.github/workflows/release-gui-linux.yml
@@ -22,12 +22,11 @@ jobs:
       - uses: ./.github/actions/setup-tauri
         with:
           signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          signing-private-key-password: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           version: ${{ inputs.version }}
 
       - name: Build GUI
         working-directory: ./gui
-        env:
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: pnpm tauri build
 
       - name: List bundle output (debug)

--- a/.github/workflows/release-gui-macos.yml
+++ b/.github/workflows/release-gui-macos.yml
@@ -22,12 +22,11 @@ jobs:
         with:
           rust-targets: aarch64-apple-darwin,x86_64-apple-darwin
           signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          signing-private-key-password: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           version: ${{ inputs.version }}
 
       - name: Build GUI
         working-directory: ./gui
-        env:
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: pnpm tauri build --target universal-apple-darwin
 
       - name: List bundle output (debug)

--- a/.github/workflows/release-gui-win.yml
+++ b/.github/workflows/release-gui-win.yml
@@ -21,12 +21,11 @@ jobs:
       - uses: ./.github/actions/setup-tauri
         with:
           signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          signing-private-key-password: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           version: ${{ inputs.version }}
 
       - name: Build GUI
         working-directory: ./gui
-        env:
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: pnpm tauri build
 
       - name: List bundle output (debug)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.10314.10703"
+version = "2026.10314.10724"
 edition = "2024"
 license = "AGPL-3.0-only"
 authors = ["TrueNine"]

--- a/cli/npm/darwin-arm64/package.json
+++ b/cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-darwin-arm64",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "os": [
     "darwin"
   ],

--- a/cli/npm/darwin-x64/package.json
+++ b/cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-darwin-x64",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "os": [
     "darwin"
   ],

--- a/cli/npm/linux-arm64-gnu/package.json
+++ b/cli/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-linux-arm64-gnu",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "os": [
     "linux"
   ],

--- a/cli/npm/linux-x64-gnu/package.json
+++ b/cli/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-linux-x64-gnu",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "os": [
     "linux"
   ],

--- a/cli/npm/win32-x64-msvc/package.json
+++ b/cli/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-win32-x64-msvc",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "os": [
     "win32"
   ],

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-cli",
   "type": "module",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "description": "TrueNine Memory Synchronization CLI",
   "author": "TrueNine",
   "license": "AGPL-3.0-only",

--- a/doc/package.json
+++ b/doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-docs",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "private": true,
   "description": "Documentation site for @truenine/memory-sync, built with Next.js 16 and MDX.",
   "engines": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-gui",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "private": true,
   "engines": {
     "node": ">=25.2.1",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-sync-gui"
-version = "2026.10314.10703"
+version = "2026.10314.10724"
 description = "Memory Sync desktop GUI application"
 authors.workspace = true
 edition.workspace = true

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "productName": "Memory Sync",
   "identifier": "org.truenine.memory-sync",
   "build": {

--- a/libraries/logger/package.json
+++ b/libraries/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/logger",
   "type": "module",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "private": true,
   "description": "Rust-powered structured logger for Node.js via N-API",
   "license": "AGPL-3.0-only",

--- a/libraries/md-compiler/package.json
+++ b/libraries/md-compiler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/md-compiler",
   "type": "module",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "private": true,
   "description": "Rust-powered MDX→Markdown compiler for Node.js with pure-TS fallback",
   "license": "AGPL-3.0-only",

--- a/libraries/script-runtime/package.json
+++ b/libraries/script-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/script-runtime",
   "type": "module",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "private": true,
   "description": "Rust-backed TypeScript proxy runtime for tnmsc",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10724",
   "description": "Cross-AI-tool prompt synchronisation toolkit (CLI + Tauri desktop GUI) — one ruleset, multi-target adaptation. Monorepo powered by pnpm + Turbo.",
   "license": "AGPL-3.0-only",
   "keywords": [


### PR DESCRIPTION
## Summary
- normalize both Tauri signing key and password inside the shared GUI setup action
- stop passing raw password secrets directly into GUI build steps
- bump workspace versions to 2026.10314.10724 after the partially published 2026.10314.10703 run

## Validation
- pnpm exec tsx .githooks/sync-versions.ts 2026.10314.10724
- workflow static contract check
- secrets rewritten with gh secret set --body