### PR TITLE
fix: attach cli archives to github release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -292,8 +292,10 @@ jobs:
 
   # 5. 构建 CLI 独立二进制（仅 artifact，不发 Release）
   build-binary:
-    needs: [check-version, publish-napi]
-    if: needs.check-version.outputs.publish == 'true'
+    needs: [check-version, check-gui-version, publish-napi]
+    if: |
+      (needs.check-version.outputs.publish == 'true' || needs.check-gui-version.outputs.should_release == 'true') &&
+      (needs.publish-napi.result == 'success' || needs.publish-napi.result == 'skipped')
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -379,7 +381,7 @@ jobs:
 
   # 7. 收集三平台产物，创建 GitHub Release + tag
   release-gui-collect:
-    needs: [check-gui-version, build-gui-all]
+    needs: [check-gui-version, build-gui-all, build-binary]
     if: needs.check-gui-version.outputs.should_release == 'true'
     permissions:
       contents: write

--- a/.github/workflows/release-gui-collect.yml
+++ b/.github/workflows/release-gui-collect.yml
@@ -20,26 +20,38 @@ jobs:
       - name: Download all GUI artifacts
         uses: actions/download-artifact@v4
         with:
-          path: artifacts
+          path: artifacts/gui
           pattern: gui-*
+          merge-multiple: true
+
+      - name: Download all CLI binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/cli
+          pattern: cli-*
           merge-multiple: true
 
       - name: Clean up unnecessary macOS artifacts
         run: |
-          find artifacts -name '*.icns' -delete
-          find artifacts -name 'Info.plist' -delete
+          find artifacts/gui -name '*.icns' -delete
+          find artifacts/gui -name 'Info.plist' -delete
 
       - name: Verify release artifacts
         shell: bash
         run: |
-          installer_count=$(find artifacts -type f \( -name '*.dmg' -o -name '*.exe' -o -name '*.msi' -o -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \) | wc -l | tr -d ' ')
-          updater_count=$(find artifacts -type f \( -name '*.sig' -o -name '*.tar.gz' -o -name '*.zip' \) | wc -l | tr -d ' ')
+          installer_count=$(find artifacts/gui -type f \( -name '*.dmg' -o -name '*.exe' -o -name '*.msi' -o -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \) | wc -l | tr -d ' ')
+          updater_count=$(find artifacts/gui -type f \( -name '*.sig' -o -name '*.tar.gz' -o -name '*.zip' \) | wc -l | tr -d ' ')
+          cli_archive_count=$(find artifacts/cli -type f \( -name '*.tar.gz' -o -name '*.zip' \) | wc -l | tr -d ' ')
           if [ "$installer_count" -eq 0 ]; then
             echo "ERROR: no GUI installer artifacts were downloaded"
             exit 1
           fi
           if [ "$updater_count" -eq 0 ]; then
             echo "ERROR: no GUI updater artifacts were downloaded"
+            exit 1
+          fi
+          if [ "$cli_archive_count" -ne 5 ]; then
+            echo "ERROR: expected 5 CLI release archives, found ${cli_archive_count}"
             exit 1
           fi
 
@@ -49,23 +61,27 @@ jobs:
           tag_name: v${{ inputs.version }}
           name: v${{ inputs.version }}
           files: |
-            artifacts/*.dmg
-            artifacts/**/*.dmg
-            artifacts/*.exe
-            artifacts/**/*.exe
-            artifacts/*.msi
-            artifacts/**/*.msi
-            artifacts/*.AppImage
-            artifacts/**/*.AppImage
-            artifacts/*.deb
-            artifacts/**/*.deb
-            artifacts/*.rpm
-            artifacts/**/*.rpm
-            artifacts/*.sig
-            artifacts/**/*.sig
-            artifacts/*.tar.gz
-            artifacts/**/*.tar.gz
-            artifacts/*.zip
-            artifacts/**/*.zip
+            artifacts/gui/*.dmg
+            artifacts/gui/**/*.dmg
+            artifacts/gui/*.exe
+            artifacts/gui/**/*.exe
+            artifacts/gui/*.msi
+            artifacts/gui/**/*.msi
+            artifacts/gui/*.AppImage
+            artifacts/gui/**/*.AppImage
+            artifacts/gui/*.deb
+            artifacts/gui/**/*.deb
+            artifacts/gui/*.rpm
+            artifacts/gui/**/*.rpm
+            artifacts/gui/*.sig
+            artifacts/gui/**/*.sig
+            artifacts/gui/*.tar.gz
+            artifacts/gui/**/*.tar.gz
+            artifacts/gui/*.zip
+            artifacts/gui/**/*.zip
+            artifacts/cli/*.tar.gz
+            artifacts/cli/**/*.tar.gz
+            artifacts/cli/*.zip
+            artifacts/cli/**/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.10314.10703"
+version = "2026.10314.10746"
 edition = "2024"
 license = "AGPL-3.0-only"
 authors = ["TrueNine"]

--- a/cli/npm/darwin-arm64/package.json
+++ b/cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-darwin-arm64",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "os": [
     "darwin"
   ],

--- a/cli/npm/darwin-x64/package.json
+++ b/cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-darwin-x64",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "os": [
     "darwin"
   ],

--- a/cli/npm/linux-arm64-gnu/package.json
+++ b/cli/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-linux-arm64-gnu",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "os": [
     "linux"
   ],

--- a/cli/npm/linux-x64-gnu/package.json
+++ b/cli/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-linux-x64-gnu",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "os": [
     "linux"
   ],

--- a/cli/npm/win32-x64-msvc/package.json
+++ b/cli/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-win32-x64-msvc",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "os": [
     "win32"
   ],

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-cli",
   "type": "module",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "description": "TrueNine Memory Synchronization CLI",
   "author": "TrueNine",
   "license": "AGPL-3.0-only",

--- a/doc/package.json
+++ b/doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-docs",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "private": true,
   "description": "Documentation site for @truenine/memory-sync, built with Next.js 16 and MDX.",
   "engines": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-gui",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "private": true,
   "engines": {
     "node": ">=25.2.1",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-sync-gui"
-version = "2026.10314.10703"
+version = "2026.10314.10746"
 description = "Memory Sync desktop GUI application"
 authors.workspace = true
 edition.workspace = true

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "productName": "Memory Sync",
   "identifier": "org.truenine.memory-sync",
   "build": {

--- a/libraries/logger/package.json
+++ b/libraries/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/logger",
   "type": "module",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "private": true,
   "description": "Rust-powered structured logger for Node.js via N-API",
   "license": "AGPL-3.0-only",

--- a/libraries/md-compiler/package.json
+++ b/libraries/md-compiler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/md-compiler",
   "type": "module",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "private": true,
   "description": "Rust-powered MDX→Markdown compiler for Node.js with pure-TS fallback",
   "license": "AGPL-3.0-only",

--- a/libraries/script-runtime/package.json
+++ b/libraries/script-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/script-runtime",
   "type": "module",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "private": true,
   "description": "Rust-backed TypeScript proxy runtime for tnmsc",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync",
-  "version": "2026.10314.10703",
+  "version": "2026.10314.10746",
   "description": "Cross-AI-tool prompt synchronisation toolkit (CLI + Tauri desktop GUI) — one ruleset, multi-target adaptation. Monorepo powered by pnpm + Turbo.",
   "license": "AGPL-3.0-only",
   "keywords": [


### PR DESCRIPTION
## Summary
- make build-binary run whenever the GitHub Release path needs CLI archives
- collect and publish CLI binary artifacts alongside GUI installer/updater assets
- bump workspace versions to 2026.10314.10746 after validating the missing-asset gap in v2026.10314.10724

## Validation
- pnpm exec tsx .githooks/sync-versions.ts 2026.10314.10746
- workflow static contract check
- verified that v2026.10314.10724 lacked CLI archives, motivating this patch