### PR TITLE
fix release asset upload duplication

### DIFF
--- a/.github/workflows/release-gui-collect.yml
+++ b/.github/workflows/release-gui-collect.yml
@@ -61,27 +61,16 @@ jobs:
           tag_name: v${{ inputs.version }}
           name: v${{ inputs.version }}
           files: |
-            artifacts/gui/*.dmg
             artifacts/gui/**/*.dmg
-            artifacts/gui/*.exe
             artifacts/gui/**/*.exe
-            artifacts/gui/*.msi
             artifacts/gui/**/*.msi
-            artifacts/gui/*.AppImage
             artifacts/gui/**/*.AppImage
-            artifacts/gui/*.deb
             artifacts/gui/**/*.deb
-            artifacts/gui/*.rpm
             artifacts/gui/**/*.rpm
-            artifacts/gui/*.sig
             artifacts/gui/**/*.sig
-            artifacts/gui/*.tar.gz
             artifacts/gui/**/*.tar.gz
-            artifacts/gui/*.zip
             artifacts/gui/**/*.zip
-            artifacts/cli/*.tar.gz
             artifacts/cli/**/*.tar.gz
-            artifacts/cli/*.zip
             artifacts/cli/**/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "memory-sync-gui"
-version = "2026.10314.10606"
+version = "2026.10314.10813"
 dependencies = [
  "dirs",
  "proptest",
@@ -4439,7 +4439,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tnmsc"
-version = "2026.10314.10606"
+version = "2026.10314.10813"
 dependencies = [
  "clap",
  "dirs",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-logger"
-version = "2026.10314.10606"
+version = "2026.10314.10813"
 dependencies = [
  "chrono",
  "napi",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-md-compiler"
-version = "2026.10314.10606"
+version = "2026.10314.10813"
 dependencies = [
  "markdown",
  "napi",
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-script-runtime"
-version = "2026.10314.10606"
+version = "2026.10314.10813"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.10314.10746"
+version = "2026.10314.10813"
 edition = "2024"
 license = "AGPL-3.0-only"
 authors = ["TrueNine"]

--- a/cli/npm/darwin-arm64/package.json
+++ b/cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-darwin-arm64",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "os": [
     "darwin"
   ],

--- a/cli/npm/darwin-x64/package.json
+++ b/cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-darwin-x64",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "os": [
     "darwin"
   ],

--- a/cli/npm/linux-arm64-gnu/package.json
+++ b/cli/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-linux-arm64-gnu",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "os": [
     "linux"
   ],

--- a/cli/npm/linux-x64-gnu/package.json
+++ b/cli/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-linux-x64-gnu",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "os": [
     "linux"
   ],

--- a/cli/npm/win32-x64-msvc/package.json
+++ b/cli/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-win32-x64-msvc",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "os": [
     "win32"
   ],

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-cli",
   "type": "module",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "description": "TrueNine Memory Synchronization CLI",
   "author": "TrueNine",
   "license": "AGPL-3.0-only",

--- a/doc/package.json
+++ b/doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-docs",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "private": true,
   "description": "Documentation site for @truenine/memory-sync, built with Next.js 16 and MDX.",
   "engines": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-gui",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "private": true,
   "engines": {
     "node": ">=25.2.1",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-sync-gui"
-version = "2026.10314.10746"
+version = "2026.10314.10813"
 description = "Memory Sync desktop GUI application"
 authors.workspace = true
 edition.workspace = true

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "productName": "Memory Sync",
   "identifier": "org.truenine.memory-sync",
   "build": {

--- a/libraries/logger/package.json
+++ b/libraries/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/logger",
   "type": "module",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "private": true,
   "description": "Rust-powered structured logger for Node.js via N-API",
   "license": "AGPL-3.0-only",

--- a/libraries/md-compiler/package.json
+++ b/libraries/md-compiler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/md-compiler",
   "type": "module",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "private": true,
   "description": "Rust-powered MDX→Markdown compiler for Node.js with pure-TS fallback",
   "license": "AGPL-3.0-only",

--- a/libraries/script-runtime/package.json
+++ b/libraries/script-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/script-runtime",
   "type": "module",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "private": true,
   "description": "Rust-backed TypeScript proxy runtime for tnmsc",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync",
-  "version": "2026.10314.10746",
+  "version": "2026.10314.10813",
   "description": "Cross-AI-tool prompt synchronisation toolkit (CLI + Tauri desktop GUI) — one ruleset, multi-target adaptation. Monorepo powered by pnpm + Turbo.",
   "license": "AGPL-3.0-only",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump version to 2026.10314.10813
- dedupe release-gui-collect asset upload globs to avoid duplicate CLI archive uploads
- include Cargo.lock version sync after local preflight

## Validation
- pnpm run build:native
- pnpm run build
- pnpm run lint
- pnpm run typecheck
- pnpm run test
- cargo test --workspace --exclude memory-sync-gui --lib --bins --tests
- cargo build --release --target x86_64-pc-windows-msvc -p tnmsc --features embedded-runtime