### PR TITLE
Release 2026.10318.11638

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "memory-sync-gui"
-version = "2026.10317.12338"
+version = "2026.10318.11638"
 dependencies = [
  "dirs",
  "proptest",
@@ -4439,7 +4439,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tnmsc"
-version = "2026.10317.12338"
+version = "2026.10318.11638"
 dependencies = [
  "clap",
  "dirs",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-logger"
-version = "2026.10317.12338"
+version = "2026.10318.11638"
 dependencies = [
  "chrono",
  "napi",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-md-compiler"
-version = "2026.10317.12338"
+version = "2026.10318.11638"
 dependencies = [
  "markdown",
  "napi",
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-script-runtime"
-version = "2026.10317.12338"
+version = "2026.10318.11638"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.10318.10339"
+version = "2026.10318.11638"
 edition = "2024"
 license = "AGPL-3.0-only"
 authors = ["TrueNine"]

--- a/cli/npm/darwin-arm64/package.json
+++ b/cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-darwin-arm64",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "os": [
     "darwin"
   ],

--- a/cli/npm/darwin-x64/package.json
+++ b/cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-darwin-x64",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "os": [
     "darwin"
   ],

--- a/cli/npm/linux-arm64-gnu/package.json
+++ b/cli/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-linux-arm64-gnu",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "os": [
     "linux"
   ],

--- a/cli/npm/linux-x64-gnu/package.json
+++ b/cli/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-linux-x64-gnu",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "os": [
     "linux"
   ],

--- a/cli/npm/win32-x64-msvc/package.json
+++ b/cli/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-win32-x64-msvc",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "os": [
     "win32"
   ],

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-cli",
   "type": "module",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "description": "TrueNine Memory Synchronization CLI",
   "author": "TrueNine",
   "license": "AGPL-3.0-only",
@@ -65,17 +65,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.lib.json"
   },
   "dependencies": {
-    "@clack/prompts": "catalog:",
-    "@truenine/script-runtime": "workspace:*",
-    "fast-glob": "catalog:",
-    "fs-extra": "catalog:",
-    "jiti": "2.6.1",
     "json5": "catalog:",
-    "lightningcss": "1.31.1",
-    "picocolors": "catalog:",
-    "picomatch": "catalog:",
-    "tsx": "4.21.0",
-    "vitest": "catalog:",
     "yaml": "2.8.2",
     "zod": "catalog:"
   },
@@ -87,11 +77,21 @@
     "@truenine/memory-sync-cli-win32-x64-msvc": "workspace:*"
   },
   "devDependencies": {
+    "@clack/prompts": "catalog:",
     "@truenine/logger": "workspace:*",
     "@truenine/md-compiler": "workspace:*",
+    "@truenine/script-runtime": "workspace:*",
     "@types/fs-extra": "catalog:",
     "@types/picomatch": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "fast-glob": "catalog:",
+    "fs-extra": "catalog:",
+    "jiti": "2.6.1",
+    "lightningcss": "1.31.1",
+    "picocolors": "catalog:",
+    "picomatch": "catalog:",
+    "tsx": "4.21.0",
+    "vitest": "catalog:",
     "zod-to-json-schema": "catalog:"
   }
 }

--- a/cli/tsdown.config.ts
+++ b/cli/tsdown.config.ts
@@ -52,6 +52,7 @@ const noExternalDeps = [
   '@truenine/logger',
   '@truenine/script-runtime',
   'fast-glob',
+  'jiti',
   '@truenine/desk-paths',
   '@truenine/md-compiler',
   ...Object.keys(pluginAliases)

--- a/doc/package.json
+++ b/doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-docs",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "private": true,
   "description": "Documentation site for @truenine/memory-sync, built with Next.js 16 and MDX.",
   "engines": {
@@ -12,17 +12,15 @@
     "start": "next start",
     "lint": "eslint ."
   },
-  "dependencies": {
+  "devDependencies": {
     "@mdx-js/react": "catalog:",
     "@next/mdx": "catalog:",
-    "next": "catalog:",
-    "react": "catalog:",
-    "react-dom": "catalog:"
-  },
-  "devDependencies": {
     "@truenine/eslint10-config": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "eslint": "catalog:"
+    "eslint": "catalog:",
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   }
 }

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-gui",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "private": true,
   "engines": {
     "node": ">=25.2.1",
@@ -22,32 +22,30 @@
     "test:tauri": "cargo test --manifest-path src-tauri/Cargo.toml --lib --bins --tests",
     "test": "pnpm run test:ui && pnpm tsx ./scripts/run-tauri-tests.ts"
   },
-  "dependencies": {
+  "devDependencies": {
     "@monaco-editor/react": "catalog:",
+    "@tailwindcss/vite": "catalog:",
     "@tanstack/react-router": "catalog:",
+    "@tanstack/router-generator": "^1.164.0",
     "@tanstack/router-plugin": "catalog:",
     "@tauri-apps/api": "catalog:",
+    "@tauri-apps/cli": "catalog:",
     "@tauri-apps/plugin-shell": "catalog:",
     "@tauri-apps/plugin-updater": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",
+    "fast-check": "catalog:",
     "lucide-react": "catalog:",
     "material-icon-theme": "^5.31.0",
     "monaco-editor": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "recharts": "^3.7.0",
-    "tailwind-merge": "catalog:"
-  },
-  "devDependencies": {
-    "@tailwindcss/vite": "catalog:",
-    "@tanstack/router-generator": "^1.164.0",
-    "@tauri-apps/cli": "catalog:",
-    "@types/react": "catalog:",
-    "@types/react-dom": "catalog:",
-    "@vitejs/plugin-react": "catalog:",
-    "fast-check": "catalog:",
     "tailwindcss": "catalog:",
+    "tailwind-merge": "catalog:",
     "tw-animate-css": "catalog:",
     "vitest": "catalog:"
   }

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-sync-gui"
-version = "2026.10318.10339"
+version = "2026.10318.11638"
 description = "Memory Sync desktop GUI application"
 authors.workspace = true
 edition.workspace = true

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "productName": "Memory Sync",
   "identifier": "org.truenine.memory-sync",
   "build": {

--- a/libraries/logger/package.json
+++ b/libraries/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/logger",
   "type": "module",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "private": true,
   "description": "Rust-powered structured logger for Node.js via N-API",
   "license": "AGPL-3.0-only",

--- a/libraries/md-compiler/package.json
+++ b/libraries/md-compiler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/md-compiler",
   "type": "module",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "private": true,
   "description": "Rust-powered MDX→Markdown compiler for Node.js with pure-TS fallback",
   "license": "AGPL-3.0-only",
@@ -54,24 +54,22 @@
     "test:ts": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit -p tsconfig.lib.json"
   },
-  "dependencies": {
-    "mdast-util-mdx": "catalog:",
-    "remark-frontmatter": "catalog:",
-    "remark-gfm": "catalog:",
-    "remark-mdx": "catalog:",
-    "remark-parse": "catalog:",
-    "remark-stringify": "catalog:",
-    "unified": "catalog:",
-    "yaml": "catalog:"
-  },
   "devDependencies": {
     "@napi-rs/cli": "^3.5.1",
     "@types/estree": "catalog:",
     "@types/estree-jsx": "catalog:",
     "@types/mdast": "catalog:",
+    "mdast-util-mdx": "catalog:",
     "npm-run-all2": "catalog:",
+    "remark-frontmatter": "catalog:",
+    "remark-gfm": "catalog:",
+    "remark-mdx": "catalog:",
+    "remark-parse": "catalog:",
+    "remark-stringify": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "unified": "catalog:",
+    "vitest": "catalog:",
+    "yaml": "catalog:"
   }
 }

--- a/libraries/script-runtime/package.json
+++ b/libraries/script-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/script-runtime",
   "type": "module",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "private": true,
   "description": "Rust-backed TypeScript proxy runtime for tnmsc",
   "license": "AGPL-3.0-only",
@@ -42,14 +42,12 @@
     "test:ts": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit -p tsconfig.lib.json"
   },
-  "dependencies": {
-    "jiti": "2.6.1"
-  },
   "devDependencies": {
     "@napi-rs/cli": "^3.5.1",
     "@truenine/eslint10-config": "catalog:",
     "@types/node": "catalog:",
     "eslint": "catalog:",
+    "jiti": "2.6.1",
     "npm-run-all2": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/libraries/script-runtime/tsdown.config.ts
+++ b/libraries/script-runtime/tsdown.config.ts
@@ -8,6 +8,9 @@ export default defineConfig([
     sourcemap: false,
     unbundle: false,
     inlineOnly: false,
+    deps: {
+      neverBundle: ['jiti']
+    },
     alias: {
       '@': resolve('src')
     },

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-mcp",
   "type": "module",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "description": "MCP stdio server for managing memory-sync prompt sources and translation artifacts",
   "author": "TrueNine",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync",
-  "version": "2026.10318.10339",
+  "version": "2026.10318.11638",
   "description": "Cross-AI-tool prompt synchronisation toolkit (CLI + Tauri desktop GUI) — one ruleset, multi-target adaptation. Monorepo powered by pnpm + Turbo.",
   "license": "AGPL-3.0-only",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,12 +224,37 @@ importers:
 
   cli:
     dependencies:
+      json5:
+        specifier: 'catalog:'
+        version: 2.2.3
+      yaml:
+        specifier: 2.8.2
+        version: 2.8.2
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
       '@clack/prompts':
         specifier: 'catalog:'
         version: 1.0.1
+      '@truenine/logger':
+        specifier: workspace:*
+        version: link:../libraries/logger
+      '@truenine/md-compiler':
+        specifier: workspace:*
+        version: link:../libraries/md-compiler
       '@truenine/script-runtime':
         specifier: workspace:*
         version: link:../libraries/script-runtime
+      '@types/fs-extra':
+        specifier: 'catalog:'
+        version: 11.0.4
+      '@types/picomatch':
+        specifier: 'catalog:'
+        version: 4.0.2
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.0.18(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       fast-glob:
         specifier: 'catalog:'
         version: 3.3.3
@@ -239,9 +264,6 @@ importers:
       jiti:
         specifier: 2.6.1
         version: 2.6.1
-      json5:
-        specifier: 'catalog:'
-        version: 2.2.3
       lightningcss:
         specifier: 1.31.1
         version: 1.31.1
@@ -257,28 +279,6 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
-      yaml:
-        specifier: 2.8.2
-        version: 2.8.2
-      zod:
-        specifier: 'catalog:'
-        version: 4.3.6
-    devDependencies:
-      '@truenine/logger':
-        specifier: workspace:*
-        version: link:../libraries/logger
-      '@truenine/md-compiler':
-        specifier: workspace:*
-        version: link:../libraries/md-compiler
-      '@types/fs-extra':
-        specifier: 'catalog:'
-        version: 11.0.4
-      '@types/picomatch':
-        specifier: 'catalog:'
-        version: 4.0.2
-      '@vitest/coverage-v8':
-        specifier: 'catalog:'
-        version: 4.0.18(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       zod-to-json-schema:
         specifier: 'catalog:'
         version: 3.25.1(zod@4.3.6)
@@ -310,23 +310,13 @@ importers:
   cli/npm/win32-x64-msvc: {}
 
   doc:
-    dependencies:
+    devDependencies:
       '@mdx-js/react':
         specifier: 'catalog:'
         version: 3.1.1(@types/react@19.2.14)(react@19.2.4)
       '@next/mdx':
         specifier: 'catalog:'
         version: 16.1.6(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))
-      next:
-        specifier: 'catalog:'
-        version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react:
-        specifier: 'catalog:'
-        version: 19.2.4
-      react-dom:
-        specifier: 'catalog:'
-        version: 19.2.4(react@19.2.4)
-    devDependencies:
       '@truenine/eslint10-config':
         specifier: 'catalog:'
         version: 2026.10209.11105(57cd6091d29b00e41b508df9848011ef)
@@ -339,33 +329,63 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.0.2(jiti@2.6.1)
+      next:
+        specifier: 'catalog:'
+        version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.4
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.4(react@19.2.4)
 
   gui:
-    dependencies:
+    devDependencies:
       '@monaco-editor/react':
         specifier: 'catalog:'
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tailwindcss/vite':
+        specifier: 'catalog:'
+        version: 4.2.1(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tanstack/react-router':
         specifier: 'catalog:'
         version: 1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/router-generator':
+        specifier: ^1.164.0
+        version: 1.164.0
       '@tanstack/router-plugin':
         specifier: 'catalog:'
         version: 1.164.0(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tauri-apps/api':
         specifier: 'catalog:'
         version: 2.10.1
+      '@tauri-apps/cli':
+        specifier: 'catalog:'
+        version: 2.10.0
       '@tauri-apps/plugin-shell':
         specifier: 'catalog:'
         version: 2.3.5
       '@tauri-apps/plugin-updater':
         specifier: 'catalog:'
         version: 2.10.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 5.1.4(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       class-variance-authority:
         specifier: 'catalog:'
         version: 0.7.1
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
+      fast-check:
+        specifier: 'catalog:'
+        version: 4.5.3
       lucide-react:
         specifier: 'catalog:'
         version: 0.575.0(react@19.2.4)
@@ -387,28 +407,6 @@ importers:
       tailwind-merge:
         specifier: 'catalog:'
         version: 3.5.0
-    devDependencies:
-      '@tailwindcss/vite':
-        specifier: 'catalog:'
-        version: 4.2.1(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      '@tanstack/router-generator':
-        specifier: ^1.164.0
-        version: 1.164.0
-      '@tauri-apps/cli':
-        specifier: 'catalog:'
-        version: 2.10.0
-      '@types/react':
-        specifier: 'catalog:'
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: 'catalog:'
-        version: 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react':
-        specifier: 'catalog:'
-        version: 5.1.4(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      fast-check:
-        specifier: 'catalog:'
-        version: 4.5.3
       tailwindcss:
         specifier: 'catalog:'
         version: 4.2.1
@@ -438,10 +436,25 @@ importers:
         version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   libraries/md-compiler:
-    dependencies:
+    devDependencies:
+      '@napi-rs/cli':
+        specifier: ^3.5.1
+        version: 3.5.1(@emnapi/runtime@1.8.1)(@types/node@25.3.3)
+      '@types/estree':
+        specifier: 'catalog:'
+        version: 1.0.8
+      '@types/estree-jsx':
+        specifier: 'catalog:'
+        version: 1.0.5
+      '@types/mdast':
+        specifier: 'catalog:'
+        version: 4.0.4
       mdast-util-mdx:
         specifier: 'catalog:'
         version: 3.0.0
+      npm-run-all2:
+        specifier: 'catalog:'
+        version: 8.0.4
       remark-frontmatter:
         specifier: 'catalog:'
         version: 5.0.0
@@ -457,43 +470,23 @@ importers:
       remark-stringify:
         specifier: 'catalog:'
         version: 11.0.0
-      unified:
-        specifier: 'catalog:'
-        version: 11.0.5
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.2
-    devDependencies:
-      '@napi-rs/cli':
-        specifier: ^3.5.1
-        version: 3.5.1(@emnapi/runtime@1.8.1)(@types/node@25.3.3)
-      '@types/estree':
-        specifier: 'catalog:'
-        version: 1.0.8
-      '@types/estree-jsx':
-        specifier: 'catalog:'
-        version: 1.0.5
-      '@types/mdast':
-        specifier: 'catalog:'
-        version: 4.0.4
-      npm-run-all2:
-        specifier: 'catalog:'
-        version: 8.0.4
       tsdown:
         specifier: 'catalog:'
         version: 0.21.0-beta.2(synckit@0.11.12)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      unified:
+        specifier: 'catalog:'
+        version: 11.0.5
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.2
 
   libraries/script-runtime:
-    dependencies:
-      jiti:
-        specifier: 2.6.1
-        version: 2.6.1
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.5.1
@@ -507,6 +500,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.0.2(jiti@2.6.1)
+      jiti:
+        specifier: 2.6.1
+        version: 2.6.1
       npm-run-all2:
         specifier: 'catalog:'
         version: 8.0.4


### PR DESCRIPTION
## Summary
- bump workspace version to 2026.10318.11638
- move unpublished package dependencies into devDependencies
- keep published CLI runtime dependencies limited to install-time requirements

## Verification
- pnpm install --lockfile-only
- npm pack --ignore-scripts for @truenine/memory-sync-cli and verify packed dependencies are json5, yaml, zod
