### PR TITLE
ci: run npm auth checks from package dirs

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -255,11 +255,13 @@ jobs:
             exit 1
           fi
 
+          pushd cli >/dev/null
           npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
           npm_user=$(npm whoami --registry "$NPM_REGISTRY_URL")
-          echo "Authenticated to npm as ${npm_user}"
-
           access_json=$(npm access list packages @truenine --json 2>/dev/null || true)
+          popd >/dev/null
+
+          echo "Authenticated to npm as ${npm_user}"
           if [[ -z "${access_json}" || "${access_json}" == "{}" || "${access_json}" == "null" ]]; then
             echo "::error::Authenticated as ${npm_user}, but npm did not report package access for @truenine. Replace NPM_TOKEN with a token that has publish permission for existing @truenine/* packages."
             exit 1
@@ -429,12 +431,15 @@ jobs:
             exit 1
           fi
 
+          pushd cli >/dev/null
           npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
           npm_user=$(npm whoami --registry "$NPM_REGISTRY_URL")
+          access_json=$(npm access list packages @truenine --json 2>/dev/null || true)
+          package_name=$(jq -r '.name' package.json)
+          popd >/dev/null
+
           echo "Authenticated to npm as ${npm_user}"
 
-          access_json=$(npm access list packages @truenine --json 2>/dev/null || true)
-          package_name=$(jq -r '.name' cli/package.json)
           package_access=$(jq -r --arg package_name "$package_name" '.[$package_name] // empty' <<<"${access_json:-{}}")
 
           if [[ "$package_access" != "read-write" ]]; then
@@ -523,12 +528,15 @@ jobs:
             exit 1
           fi
 
+          pushd mcp >/dev/null
           npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
           npm_user=$(npm whoami --registry "$NPM_REGISTRY_URL")
+          access_json=$(npm access list packages @truenine --json 2>/dev/null || true)
+          package_name=$(jq -r '.name' package.json)
+          popd >/dev/null
+
           echo "Authenticated to npm as ${npm_user}"
 
-          access_json=$(npm access list packages @truenine --json 2>/dev/null || true)
-          package_name=$(jq -r '.name' mcp/package.json)
           package_access=$(jq -r --arg package_name "$package_name" '.[$package_name] // empty' <<<"${access_json:-{}}")
 
           if [[ "$package_access" != "read-write" ]]; then


### PR DESCRIPTION
## Summary
- run npm auth preflight from package directories instead of the workspace root
- avoid npm 11 failing on root package metadata before auth checks execute

## Validation
- python -c " import pathlib yaml