### PR TITLE
fix: repair docs deploy and windows path test

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -50,10 +50,10 @@ jobs:
           fi
 
       - name: Pull Vercel production settings
-        run: pnpm dlx vercel@latest pull --yes --environment=production --cwd doc --token="$VERCEL_TOKEN"
+        run: pnpm dlx vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Build docs on Vercel
-        run: pnpm dlx vercel@latest build --prod --cwd doc --token="$VERCEL_TOKEN"
+        run: pnpm dlx vercel@latest build --prod --token="$VERCEL_TOKEN"
 
       - name: Deploy docs to Vercel production
-        run: pnpm dlx vercel@latest deploy --prebuilt --prod --cwd doc --token="$VERCEL_TOKEN"
+        run: pnpm dlx vercel@latest deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/cli/src/runtime-environment.test.ts
+++ b/cli/src/runtime-environment.test.ts
@@ -51,7 +51,7 @@ describe('runtime environment', () => {
         USERPROFILE: windowsHomeDir
       },
       homedir: windowsHomeDir
-    })).toBe(path.join(windowsHomeDir, '.codex', 'config.toml'))
+    })).toBe(path.win32.join(windowsHomeDir, '.codex', 'config.toml'))
   })
 
   it('selects the host config path that matches the current Windows profile in WSL', () => {


### PR DESCRIPTION
## Summary
- remove redundant Vercel cwd override in docs deployment workflow
- assert Windows path resolution with Windows path semantics in runtime environment tests

## Verification
- pnpm -C cli exec vitest run src/runtime-environment.test.ts
- pnpm -C doc build
- pnpm run test
