### PR TITLE
Fix Windows cleanup path normalization

### DIFF
--- a/cli/src/core/cleanup.rs
+++ b/cli/src/core/cleanup.rs
@@ -233,7 +233,7 @@ fn resolve_absolute_path(raw_path: &str) -> PathBuf {
 }
 
 fn path_to_string(path: &Path) -> String {
-    path.to_string_lossy().into_owned()
+    normalize_path(path).to_string_lossy().into_owned()
 }
 
 fn path_to_glob_string(path: &Path) -> String {


### PR DESCRIPTION
## Summary
- normalize cleanup path string conversion before serializing paths
- align Windows test/runtime path comparisons to a single separator form
- unblock the failed `Release Packages` windows binary test job on `main`

## Validation
- cargo test -p tnmsc cleanup -- --nocapture
- cargo test -p tnmsc --lib --bins --tests