### PR TITLE
fix(release): build cli napi artifacts from sdk

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -8,7 +8,7 @@ env:
     libraries/logger
     libraries/md-compiler
     libraries/script-runtime
-    cli
+    sdk
   CLI_NATIVE_BINDING_PREFIXES: |
     napi-logger.
     napi-md-compiler.


### PR DESCRIPTION
## Summary
- build CLI native npm artifacts from `sdk` instead of the Rust shell in `cli`
- unblock `build-napi` so `publish-cli` and `publish-mcp` can run again

## Root cause
`release-cli.yml` tried to run `napi build --features napi` inside `cli/`, but `tnmsc-cli-shell` has no `napi` feature. The actual NAPI crate is `sdk/`.

## Validation
- local targeted check confirmed the same `napi build ... --features napi` command succeeds in `sdk/`
- GitHub Actions on merge will run the real multi-platform release path