### PR TITLE
Update CLI release workflow to publish the SDK crate

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -8,7 +8,7 @@ env:
     libraries/logger
     libraries/md-compiler
     libraries/script-runtime
-    cli
+    sdk
   CLI_NATIVE_BINDING_PREFIXES: |
     napi-logger.
     napi-md-compiler.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "memory-sync-gui"
-version = "2026.10330.118"
+version = "2026.10402.103"
 dependencies = [
  "dirs",
  "proptest",
@@ -4436,7 +4436,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tnmsc"
-version = "2026.10330.118"
+version = "2026.10402.103"
 dependencies = [
  "clap",
  "dirs",
@@ -4458,7 +4458,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-cli-shell"
-version = "2026.10330.118"
+version = "2026.10402.103"
 dependencies = [
  "clap",
  "serde_json",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-logger"
-version = "2026.10330.118"
+version = "2026.10402.103"
 dependencies = [
  "napi",
  "napi-build",
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-md-compiler"
-version = "2026.10330.118"
+version = "2026.10402.103"
 dependencies = [
  "markdown",
  "napi",
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-script-runtime"
-version = "2026.10330.118"
+version = "2026.10402.103"
 dependencies = [
  "napi",
  "napi-build",


### PR DESCRIPTION
## Summary
- switch the CLI release workflow package path from `cli` to `sdk`
- align `Cargo.lock` crate versions with the current `2026.10402.103` release
- keep the release pipeline pointed at the crate that now owns the `tnmsc` surface

## Testing
- Not run (not requested)