### PR TITLE
fix(release): build cli shell binary in release workflow

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -746,10 +746,10 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
       - name: Build tnmsc binary (release, with embedded runtime)
-        run: cargo build --release --target ${{ matrix.target }} -p tnmsc --features embedded-runtime
+        run: cargo build --release --target ${{ matrix.target }} -p tnmsc-cli-shell --features tnmsc/embedded-runtime
       - name: Run tests (native only)
         if: ${{ !matrix.cross }}
-        run: cargo test --release --target ${{ matrix.target }} -p tnmsc --features embedded-runtime
+        run: cargo test --release --target ${{ matrix.target }} -p tnmsc-cli-shell --features tnmsc/embedded-runtime
       - name: Package (unix)
         if: runner.os != 'Windows'
         shell: bash


### PR DESCRIPTION
## Summary
- build the `tnmsc` binary from `tnmsc-cli-shell`, which is the workspace package that actually owns the CLI executable
- enable the SDK `embedded-runtime` feature through the CLI shell package so the packaged binary still embeds `plugin-runtime.mjs`
- leave the packaging paths unchanged now that the expected `target/.../release/tnmsc[.exe]` artifact is produced again

## Root Cause
`Release Packages` was compiling `-p tnmsc`, but `tnmsc` is the SDK library crate, not the CLI shell package with the `[[bin]] name = "tnmsc"` target. The build step succeeded, but the later package steps on macOS and Windows failed because `target/<triple>/release/tnmsc` was never created.

## Validation
- `pnpm -F @truenine/memory-sync-cli run build`
- `cargo build --release --target x86_64-unknown-linux-gnu -p tnmsc-cli-shell --features tnmsc/embedded-runtime`
- `cargo test --release --target x86_64-unknown-linux-gnu -p tnmsc-cli-shell --features tnmsc/embedded-runtime`
