### PR TITLE
Update workspace package versions to 2026.10408.12323

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "memory-sync-gui"
-version = "2026.10406.121"
+version = "2026.10408.12323"
 dependencies = [
  "dirs",
  "proptest",
@@ -4436,7 +4436,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tnmsc"
-version = "2026.10406.121"
+version = "2026.10408.12323"
 dependencies = [
  "clap",
  "dirs",
@@ -4458,7 +4458,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-cli-shell"
-version = "2026.10406.121"
+version = "2026.10408.12323"
 dependencies = [
  "clap",
  "serde_json",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-logger"
-version = "2026.10406.121"
+version = "2026.10408.12323"
 dependencies = [
  "napi",
  "napi-build",
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-md-compiler"
-version = "2026.10406.121"
+version = "2026.10408.12323"
 dependencies = [
  "markdown",
  "napi",
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "tnmsc-script-runtime"
-version = "2026.10406.121"
+version = "2026.10408.12323"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.10406.121"
+version = "2026.10408.12323"
 edition = "2024"
 rust-version = "1.88"
 license = "AGPL-3.0-only"

--- a/cli/npm/darwin-arm64/package.json
+++ b/cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-darwin-arm64",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "os": [
     "darwin"
   ],

--- a/cli/npm/darwin-x64/package.json
+++ b/cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-darwin-x64",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "os": [
     "darwin"
   ],

--- a/cli/npm/linux-arm64-gnu/package.json
+++ b/cli/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-linux-arm64-gnu",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "os": [
     "linux"
   ],

--- a/cli/npm/linux-x64-gnu/package.json
+++ b/cli/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-linux-x64-gnu",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "os": [
     "linux"
   ],

--- a/cli/npm/win32-x64-msvc/package.json
+++ b/cli/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-cli-win32-x64-msvc",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "os": [
     "win32"
   ],

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-cli",
   "type": "module",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "description": "TrueNine Memory Synchronization CLI shell",
   "author": "TrueNine",
   "license": "AGPL-3.0-only",

--- a/doc/package.json
+++ b/doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-docs",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "private": true,
   "description": "Chinese-first manifesto-led documentation site for @truenine/memory-sync.",
   "engines": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync-gui",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "private": true,
   "engines": {
     "node": ">= 22"

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-sync-gui"
-version = "2026.10406.121"
+version = "2026.10408.12323"
 description = "Memory Sync desktop GUI application"
 authors.workspace = true
 edition.workspace = true

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "productName": "Memory Sync",
   "identifier": "org.truenine.memory-sync",
   "build": {

--- a/libraries/logger/package.json
+++ b/libraries/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/logger",
   "type": "module",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "private": true,
   "description": "Rust-powered AI-friendly Markdown logger for Node.js via N-API",
   "license": "AGPL-3.0-only",

--- a/libraries/md-compiler/package.json
+++ b/libraries/md-compiler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/md-compiler",
   "type": "module",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "private": true,
   "description": "Rust-powered MDX→Markdown compiler for Node.js with pure-TS fallback",
   "license": "AGPL-3.0-only",

--- a/libraries/script-runtime/package.json
+++ b/libraries/script-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/script-runtime",
   "type": "module",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "private": true,
   "description": "Rust-backed TypeScript proxy runtime for tnmsc",
   "license": "AGPL-3.0-only",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-mcp",
   "type": "module",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "description": "MCP stdio server for managing memory-sync prompt sources and translation artifacts",
   "author": "TrueNine",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truenine/memory-sync",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "description": "Cross-AI-tool prompt synchronisation toolkit (CLI + Tauri desktop GUI) — one ruleset, multi-target adaptation. Monorepo powered by pnpm + Turbo.",
   "license": "AGPL-3.0-only",
   "keywords": [

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@truenine/memory-sync-sdk",
   "type": "module",
-  "version": "2026.10406.121",
+  "version": "2026.10408.12323",
   "private": true,
   "description": "TrueNine Memory Synchronization SDK",
   "author": "TrueNine",

--- a/sdk/src/plugins/plugin-core/AbstractOutputPlugin.ts
+++ b/sdk/src/plugins/plugin-core/AbstractOutputPlugin.ts
@@ -28,6 +28,7 @@ import type {
   SkillChildDoc,
   SkillPrompt,
   SkillResource,
+  SubAgentYAMLFrontMatter,
   SubAgentPrompt,
   WslMirrorFileDeclaration
 } from './types'
@@ -146,7 +147,7 @@ export interface SubAgentsOutputConfig extends ScopedSourceConfig {
   readonly transformFrontMatter?: (
     subAgent: SubAgentPrompt,
     context: {
-      readonly sourceFrontMatter?: Record<string, unknown>
+      readonly sourceFrontMatter?: SubAgentYAMLFrontMatter
     }
   ) => Record<string, unknown>
 }
@@ -336,7 +337,7 @@ export abstract class AbstractOutputPlugin extends AbstractPlugin implements Out
     readonly transformFrontMatter?: (
       subAgent: SubAgentPrompt,
       context: {
-        readonly sourceFrontMatter?: Record<string, unknown>
+        readonly sourceFrontMatter?: SubAgentYAMLFrontMatter
       }
     ) => Record<string, unknown>
   }
@@ -1480,7 +1481,7 @@ export abstract class AbstractOutputPlugin extends AbstractPlugin implements Out
     const subAgentFrontMatterTransformer = this.subAgentsConfig.transformFrontMatter
     const transformedFrontMatter = subAgentFrontMatterTransformer?.(agent, {
       ...agent.yamlFrontMatter != null && {
-        sourceFrontMatter: agent.yamlFrontMatter as Record<string, unknown>
+        sourceFrontMatter: agent.yamlFrontMatter
       }
     })
 


### PR DESCRIPTION
## Summary
- Bump workspace package versions from `2026.10406.121` to `2026.10408.12323`
- Sync Rust, Node, CLI, GUI, docs, SDK, MCP, and library package metadata to the new release version
- Update Tauri and Cargo manifests to keep release artifacts aligned

## Testing
- Not run (not requested)