### PR TITLE
fix(ci): fix GitHub Actions artifact paths

### DIFF
--- a/.github/actions/build-gui-platform/action.yml
+++ b/.github/actions/build-gui-platform/action.yml
@@ -48,7 +48,7 @@ runs:
       shell: bash
       run: |
         echo "=== Finding all bundle artifacts ==="
-        find gui/src-tauri/target -path '*/bundle/*' -type f 2>/dev/null || echo 'No bundle files found'
+        find gui/target -path '*/bundle/*' -type f 2>/dev/null || echo 'No bundle files found'
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v7

--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -91,7 +91,7 @@ runs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-          gui/src-tauri/target
+          gui/target
         key: ${{ runner.os }}-cargo-${{ inputs.rust-version }}-${{ steps.cargo-deps-hash.outputs.hash }}
         restore-keys: |
           ${{ runner.os }}-cargo-${{ inputs.rust-version }}-
@@ -113,6 +113,6 @@ runs:
     - name: Clean old bundle artifacts
       shell: bash
       run: |
-        if [ -d "gui/src-tauri/target" ]; then
-          find gui/src-tauri/target -type d -name bundle -prune -exec rm -rf {} +
+        if [ -d "gui/target" ]; then
+          find gui/target -type d -name bundle -prune -exec rm -rf {} +
         fi

--- a/.github/workflows/build-gui-all.yml
+++ b/.github/workflows/build-gui-all.yml
@@ -17,35 +17,35 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            rust-targets: ''
+            rust-targets: ""
             tauri-command: pnpm tauri build
             artifact-path: |
-              gui/src-tauri/target/*/release/bundle/**/*.exe
-              gui/src-tauri/target/release/bundle/**/*.exe
-              gui/src-tauri/target/*/release/bundle/**/*.sig
-              gui/src-tauri/target/release/bundle/**/*.sig
+              target/*/release/bundle/**/*.exe
+              target/release/bundle/**/*.exe
+              target/*/release/bundle/**/*.sig
+              target/release/bundle/**/*.sig
           - os: ubuntu-24.04
-            rust-targets: ''
+            rust-targets: ""
             tauri-command: pnpm tauri build
             artifact-path: |
-              gui/src-tauri/target/*/release/bundle/**/*.AppImage
-              gui/src-tauri/target/*/release/bundle/**/*.deb
-              gui/src-tauri/target/*/release/bundle/**/*.rpm
-              gui/src-tauri/target/*/release/bundle/**/*.sig
-              gui/src-tauri/target/release/bundle/**/*.AppImage
-              gui/src-tauri/target/release/bundle/**/*.deb
-              gui/src-tauri/target/release/bundle/**/*.rpm
-              gui/src-tauri/target/release/bundle/**/*.sig
+              target/*/release/bundle/**/*.AppImage
+              target/*/release/bundle/**/*.deb
+              target/*/release/bundle/**/*.rpm
+              target/*/release/bundle/**/*.sig
+              target/release/bundle/**/*.AppImage
+              target/release/bundle/**/*.deb
+              target/release/bundle/**/*.rpm
+              target/release/bundle/**/*.sig
           - os: macos-14
             rust-targets: aarch64-apple-darwin,x86_64-apple-darwin
             tauri-command: pnpm tauri build --target universal-apple-darwin
             artifact-path: |
-              gui/src-tauri/target/*/release/bundle/**/*.dmg
-              gui/src-tauri/target/*/release/bundle/**/*.tar.gz
-              gui/src-tauri/target/*/release/bundle/**/*.sig
-              gui/src-tauri/target/release/bundle/**/*.dmg
-              gui/src-tauri/target/release/bundle/**/*.tar.gz
-              gui/src-tauri/target/release/bundle/**/*.sig
+              target/*/release/bundle/**/*.dmg
+              target/*/release/bundle/**/*.tar.gz
+              target/*/release/bundle/**/*.sig
+              target/release/bundle/**/*.dmg
+              target/release/bundle/**/*.tar.gz
+              target/release/bundle/**/*.sig
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release-gui-linux.yml
+++ b/.github/workflows/release-gui-linux.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to rebuild for debugging (without v prefix, e.g. 2026.10213.0)'
+        description: "Version to rebuild for debugging (without v prefix, e.g. 2026.10213.0)"
         required: true
         type: string
 
@@ -23,14 +23,14 @@ jobs:
           tauri-command: pnpm tauri build
           artifact-name: debug-gui-ubuntu-24.04
           artifact-path: |
-            gui/src-tauri/target/*/release/bundle/**/*.AppImage
-            gui/src-tauri/target/release/bundle/**/*.AppImage
-            gui/src-tauri/target/*/release/bundle/**/*.deb
-            gui/src-tauri/target/release/bundle/**/*.deb
-            gui/src-tauri/target/*/release/bundle/**/*.rpm
-            gui/src-tauri/target/release/bundle/**/*.rpm
-            gui/src-tauri/target/*/release/bundle/**/*.sig
-            gui/src-tauri/target/release/bundle/**/*.sig
+            target/*/release/bundle/**/*.AppImage
+            target/release/bundle/**/*.AppImage
+            target/*/release/bundle/**/*.deb
+            target/release/bundle/**/*.deb
+            target/*/release/bundle/**/*.rpm
+            target/release/bundle/**/*.rpm
+            target/*/release/bundle/**/*.sig
+            target/release/bundle/**/*.sig
           signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           signing-private-key-password: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           version: ${{ inputs.version }}

--- a/.github/workflows/release-gui-macos.yml
+++ b/.github/workflows/release-gui-macos.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to rebuild for debugging (without v prefix, e.g. 2026.10213.0)'
+        description: "Version to rebuild for debugging (without v prefix, e.g. 2026.10213.0)"
         required: true
         type: string
 
@@ -22,12 +22,12 @@ jobs:
           tauri-command: pnpm tauri build --target universal-apple-darwin
           artifact-name: debug-gui-macos-14
           artifact-path: |
-            gui/src-tauri/target/*/release/bundle/**/*.dmg
-            gui/src-tauri/target/*/release/bundle/**/*.tar.gz
-            gui/src-tauri/target/*/release/bundle/**/*.sig
-            gui/src-tauri/target/release/bundle/**/*.dmg
-            gui/src-tauri/target/release/bundle/**/*.tar.gz
-            gui/src-tauri/target/release/bundle/**/*.sig
+            target/*/release/bundle/**/*.dmg
+            target/*/release/bundle/**/*.tar.gz
+            target/*/release/bundle/**/*.sig
+            target/release/bundle/**/*.dmg
+            target/release/bundle/**/*.tar.gz
+            target/release/bundle/**/*.sig
           rust-targets: aarch64-apple-darwin,x86_64-apple-darwin
           signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           signing-private-key-password: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/.github/workflows/release-gui-win.yml
+++ b/.github/workflows/release-gui-win.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to rebuild for debugging (without v prefix, e.g. 2026.10213.0)'
+        description: "Version to rebuild for debugging (without v prefix, e.g. 2026.10213.0)"
         required: true
         type: string
 
@@ -23,10 +23,10 @@ jobs:
           tauri-command: pnpm tauri build
           artifact-name: debug-gui-windows-latest
           artifact-path: |
-            gui/src-tauri/target/*/release/bundle/**/*.exe
-            gui/src-tauri/target/*/release/bundle/**/*.sig
-            gui/src-tauri/target/release/bundle/**/*.exe
-            gui/src-tauri/target/release/bundle/**/*.sig
+            target/*/release/bundle/**/*.exe
+            target/*/release/bundle/**/*.sig
+            target/release/bundle/**/*.exe
+            target/release/bundle/**/*.sig
           signing-private-key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           signing-private-key-password: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           version: ${{ inputs.version }}


### PR DESCRIPTION
## Summary
- Fix GitHub Actions artifact upload paths from `gui/src-tauri/target` to `gui/target`
- Update cache and clean paths in setup-tauri action
- Update all workflow artifact-path patterns