### PR TITLE
ci: fix docs deploy package manager detection

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -97,10 +97,10 @@ jobs:
           fi
 
       - name: Pull Vercel production settings
-        run: pnpm dlx vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
+        run: pnpm dlx vercel@latest --cwd doc pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Build docs on Vercel
-        run: pnpm dlx vercel@latest build --prod --token="$VERCEL_TOKEN"
+        run: pnpm dlx vercel@latest --cwd doc build --prod --token="$VERCEL_TOKEN"
 
       - name: Deploy docs to Vercel production
-        run: pnpm dlx vercel@latest deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+        run: pnpm dlx vercel@latest --cwd doc deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/doc/package.json
+++ b/doc/package.json
@@ -2,11 +2,11 @@
   "name": "@truenine/memory-sync-docs",
   "version": "2026.10422.10749",
   "private": true,
+  "packageManager": "pnpm@10.33.0",
   "description": "Chinese-first manifesto-led documentation site for @truenine/memory-sync.",
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "tsx scripts/run-next.ts dev",
     "build": "tsx scripts/validate-content.ts && tsx scripts/run-next.ts build",

--- a/doc/package.json
+++ b/doc/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=22"
   },
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "tsx scripts/run-next.ts dev",
     "build": "tsx scripts/validate-content.ts && tsx scripts/run-next.ts build",


### PR DESCRIPTION
## Summary
- run Vercel docs pull/build/deploy from the doc workspace
- declare the docs package manager explicitly as pnpm
- keep docs deployment aligned with the workspace catalog-based dependencies

## Testing
- cargo run -p xtask -- doc-build