### PR TITLE
ci: fix vercel docs project root resolution

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -97,10 +97,10 @@ jobs:
           fi
 
       - name: Pull Vercel production settings
-        run: pnpm dlx vercel@latest --cwd doc pull --yes --environment=production --token="$VERCEL_TOKEN"
+        run: pnpm dlx vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Build docs on Vercel
-        run: pnpm dlx vercel@latest --cwd doc build --prod --token="$VERCEL_TOKEN"
+        run: pnpm dlx vercel@latest build --prod --token="$VERCEL_TOKEN"
 
       - name: Deploy docs to Vercel production
-        run: pnpm dlx vercel@latest --cwd doc deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+        run: pnpm dlx vercel@latest deploy --prebuilt --prod --token="$VERCEL_TOKEN"


### PR DESCRIPTION
## Summary
- keep the docs packageManager declaration so Vercel detects pnpm
- remove the extra --cwd doc flags because the Vercel project already targets the docs root
- fix the main-branch docs deployment path resolution failure

## Testing
- analyzed failed main docs deploy logs for run 24759964301