### PR TITLE
ci: isolate npm auth from repo package metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,8 +264,13 @@ jobs:
             exit 1
           fi
 
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "$tmp_dir"' EXIT
+
+          pushd "$tmp_dir" >/dev/null
           npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
           npm whoami --registry "${NPM_REGISTRY_URL}"
+          popd >/dev/null
 
       - name: Download raw CLI binaries
         uses: actions/download-artifact@v8
@@ -335,8 +340,13 @@ jobs:
             exit 1
           fi
 
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "$tmp_dir"' EXIT
+
+          pushd "$tmp_dir" >/dev/null
           npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
           npm whoami --registry "${NPM_REGISTRY_URL}"
+          popd >/dev/null
 
       - name: Download raw MCP binaries
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary
- run npm auth preflight from a temporary directory in the release workflow
- avoid npm reading the repo root package.json during whoami checks
- fix the publish-cli-npm / publish-mcp-npm preflight failure in release run 24761876771

## Rationale
- npm whoami was failing on the repo root package metadata before any publish step could start