### PR TITLE
cleanup(localized_reader): drop unused `seen` HashSet (#190)

### DIFF
--- a/cli/local-tests/tests/logging_error_feedback.rs
+++ b/cli/local-tests/tests/logging_error_feedback.rs
@@ -30,21 +30,24 @@ fn missing_config_outputs_diagnostic_with_fix() {
   assert!(
     result.stderr.contains("What happened") || result.stdout.contains("What happened"),
     "error should contain 'What happened' section. stdout:\n{}\nstderr:\n{}",
-    result.stdout, result.stderr
+    result.stdout,
+    result.stderr
   );
 
   // 验证有修复建议（嵌入在错误消息中）
   assert!(
     result.stderr.contains("Please create it") || result.stdout.contains("Please create it"),
     "error should contain fix suggestion. stdout:\n{}\nstderr:\n{}",
-    result.stdout, result.stderr
+    result.stdout,
+    result.stderr
   );
 
   // 验证提及配置文件
   assert!(
     result.stderr.contains(".tnmsc.json") || result.stdout.contains(".tnmsc.json"),
     "error should mention .tnmsc.json. stdout:\n{}\nstderr:\n{}",
-    result.stdout, result.stderr
+    result.stdout,
+    result.stderr
   );
 }
 

--- a/cli/local-tests/tests/logging_install_observability.rs
+++ b/cli/local-tests/tests/logging_install_observability.rs
@@ -49,7 +49,9 @@ fn install_outputs_key_spans_and_events() {
 
   // 验证 collector span
   assert!(
-    result.stdout.contains("### collect.aindex_resolvers started"),
+    result
+      .stdout
+      .contains("### collect.aindex_resolvers started"),
     "install should output 'collect.aindex_resolvers' span. stdout:\n{}",
     result.stdout
   );

--- a/cli/local-tests/tests/logging_levels.rs
+++ b/cli/local-tests/tests/logging_levels.rs
@@ -16,7 +16,9 @@ fn trace_level_outputs_span_events() {
 
   // Trace 级别应该输出 collector span
   assert!(
-    result.stdout.contains("### collect.aindex_resolvers started"),
+    result
+      .stdout
+      .contains("### collect.aindex_resolvers started"),
     "--trace should output collector spans. stdout:\n{}",
     result.stdout
   );

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -112,8 +112,6 @@ impl ResolvedLogLevel {
       Self::Error => "error",
     }
   }
-
-
 }
 
 /// Resolve log level from CLI flags.

--- a/mcp/integrate-tests/tests/packaging_smoke.rs
+++ b/mcp/integrate-tests/tests/packaging_smoke.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -327,7 +327,7 @@ fn main() -> ExitCode {
     std::env::var("LOG_LEVEL")
       .ok()
       .and_then(|s| tnmsd::infra::logger::LogLevel::from_str_loose(&s))
-      .unwrap_or(tnmsd::infra::logger::LogLevel::Info)
+      .unwrap_or(tnmsd::infra::logger::LogLevel::Info),
   );
 
   let cli = Cli::parse();
@@ -336,10 +336,13 @@ fn main() -> ExitCode {
   match resolve_command(&cli) {
     ResolvedCommand::Serve => {
       let _span = logger.span("server.serve").enter();
-      logger.info("MCP server started", Some(json!({
-        "serverName": SERVER_NAME,
-        "protocolVersion": PROTOCOL_VERSION,
-      })));
+      logger.info(
+        "MCP server started",
+        Some(json!({
+          "serverName": SERVER_NAME,
+          "protocolVersion": PROTOCOL_VERSION,
+        })),
+      );
       run_stdio_server();
       ExitCode::SUCCESS
     }

--- a/sdk/src/domain/output_plans/codex_output_plan.rs
+++ b/sdk/src/domain/output_plans/codex_output_plan.rs
@@ -18,11 +18,11 @@
 use std::path::PathBuf;
 
 use crate::CliError;
-use crate::domain::output_context::OutputContext;
 use crate::domain::base_output_plans::{BaseOutputFileDeclarationDto, BaseOutputPluginPlanDto};
-use crate::domain::config;
-use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 use crate::domain::cleanup::{CleanupDeclarationsDto, CleanupTargetDto, CleanupTargetKindDto};
+use crate::domain::config;
+use crate::domain::output_context::OutputContext;
+use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 
 const CODEX_PLUGIN_NAME: &str = "CodexCLIOutputAdaptor";
 const CODEX_INSTRUCTIONS_FILE: &str = "AGENTS.md";

--- a/sdk/src/domain/output_plans/cursor_output_plan.rs
+++ b/sdk/src/domain/output_plans/cursor_output_plan.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
 use crate::CliError;
-use crate::domain::output_context::OutputContext;
 use crate::domain::base_output_plans::{BaseOutputFileDeclarationDto, BaseOutputPluginPlanDto};
-use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 use crate::domain::cleanup::{CleanupDeclarationsDto, CleanupTargetDto, CleanupTargetKindDto};
+use crate::domain::output_context::OutputContext;
+use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 
 const CURSOR_PLUGIN_NAME: &str = "CursorOutputAdaptor";
 const CURSOR_MEMORY_FILE: &str = ".cursorrules";

--- a/sdk/src/domain/output_plans/droid_output_plan.rs
+++ b/sdk/src/domain/output_plans/droid_output_plan.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use crate::CliError;
-use crate::domain::output_context::OutputContext;
+use crate::domain::cleanup::{CleanupDeclarationsDto, CleanupTargetDto, CleanupTargetKindDto};
 use crate::domain::config;
+use crate::domain::output_context::OutputContext;
 use crate::domain::plugin_shared::{
   FastCommandPrompt, Project, RelativePath, RuleScope, SkillPrompt, SkillResourceEncoding,
   Workspace,
 };
-use crate::domain::cleanup::{CleanupDeclarationsDto, CleanupTargetDto, CleanupTargetKindDto};
 
 const DROID_PLUGIN_NAME: &str = "DroidCLIOutputAdaptor";
 const DROID_MEMORY_FILE: &str = "AGENTS.md";

--- a/sdk/src/domain/output_plans/gemini_output_plan.rs
+++ b/sdk/src/domain/output_plans/gemini_output_plan.rs
@@ -2,11 +2,11 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 use crate::CliError;
-use crate::domain::output_context::OutputContext;
 use crate::domain::base_output_plans::{BaseOutputFileDeclarationDto, BaseOutputPluginPlanDto};
-use crate::domain::config;
-use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 use crate::domain::cleanup::{CleanupDeclarationsDto, CleanupTargetDto, CleanupTargetKindDto};
+use crate::domain::config;
+use crate::domain::output_context::OutputContext;
+use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 
 const GEMINI_PLUGIN_NAME: &str = "GeminiCLIOutputAdaptor";
 const GEMINI_MEMORY_FILE: &str = "GEMINI.md";

--- a/sdk/src/domain/output_plans/generic_skills_output_plan.rs
+++ b/sdk/src/domain/output_plans/generic_skills_output_plan.rs
@@ -1,8 +1,8 @@
 use crate::CliError;
-use crate::domain::output_context::OutputContext;
 use crate::domain::base_output_plans::BaseOutputPluginPlanDto;
-use crate::domain::plugin_shared::Workspace;
 use crate::domain::cleanup::CleanupDeclarationsDto;
+use crate::domain::output_context::OutputContext;
+use crate::domain::plugin_shared::Workspace;
 
 const GENERIC_SKILLS_PLUGIN_NAME: &str = "GenericSkillsOutputAdaptor";
 

--- a/sdk/src/domain/output_plans/kiro_output_plan.rs
+++ b/sdk/src/domain/output_plans/kiro_output_plan.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
 use crate::CliError;
-use crate::domain::output_context::OutputContext;
 use crate::domain::base_output_plans::BaseOutputPluginPlanDto;
-use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 use crate::domain::cleanup::{CleanupDeclarationsDto, CleanupTargetDto, CleanupTargetKindDto};
+use crate::domain::output_context::OutputContext;
+use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 
 const KIRO_PLUGIN_NAME: &str = "KiroCLIOutputAdaptor";
 const PROJECT_SCOPE: &str = "project";

--- a/sdk/src/domain/output_plans/opencode_output_plan.rs
+++ b/sdk/src/domain/output_plans/opencode_output_plan.rs
@@ -3,11 +3,11 @@ use std::path::PathBuf;
 use serde_json::Value;
 
 use crate::CliError;
-use crate::domain::output_context::OutputContext;
 use crate::domain::base_output_plans::{BaseOutputFileDeclarationDto, BaseOutputPluginPlanDto};
-use crate::domain::config;
-use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 use crate::domain::cleanup::{CleanupDeclarationsDto, CleanupTargetDto, CleanupTargetKindDto};
+use crate::domain::config;
+use crate::domain::output_context::OutputContext;
+use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 
 const OPENCODE_PLUGIN_NAME: &str = "OpencodeCLIOutputAdaptor";
 const OPENCODE_MEMORY_FILE: &str = "AGENTS.md";

--- a/sdk/src/domain/output_plans/qoder_output_plan.rs
+++ b/sdk/src/domain/output_plans/qoder_output_plan.rs
@@ -1,8 +1,8 @@
 use crate::CliError;
-use crate::domain::output_context::OutputContext;
 use crate::domain::base_output_plans::BaseOutputPluginPlanDto;
-use crate::domain::plugin_shared::Workspace;
 use crate::domain::cleanup::CleanupDeclarationsDto;
+use crate::domain::output_context::OutputContext;
+use crate::domain::plugin_shared::Workspace;
 
 const QODER_PLUGIN_NAME: &str = "QoderIDEPluginOutputAdaptor";
 

--- a/sdk/src/domain/output_plans/trae_output_plan.rs
+++ b/sdk/src/domain/output_plans/trae_output_plan.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
 use crate::CliError;
-use crate::domain::output_context::OutputContext;
 use crate::domain::base_output_plans::{BaseOutputFileDeclarationDto, BaseOutputPluginPlanDto};
-use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 use crate::domain::cleanup::{CleanupDeclarationsDto, CleanupTargetDto, CleanupTargetKindDto};
+use crate::domain::output_context::OutputContext;
+use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 
 const TRAE_PLUGIN_NAME: &str = "TraeOutputAdaptor";
 const TRAE_STEERING_FILE: &str = "GLOBAL.md";

--- a/sdk/src/domain/output_plans/warp_output_plan.rs
+++ b/sdk/src/domain/output_plans/warp_output_plan.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
 use crate::CliError;
-use crate::domain::output_context::OutputContext;
 use crate::domain::base_output_plans::{BaseOutputFileDeclarationDto, BaseOutputPluginPlanDto};
-use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 use crate::domain::cleanup::{CleanupDeclarationsDto, CleanupTargetDto, CleanupTargetKindDto};
+use crate::domain::output_context::OutputContext;
+use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 
 const WARP_PLUGIN_NAME: &str = "WarpIDEOutputAdaptor";
 const WARP_MEMORY_FILE: &str = "WARP.md";

--- a/sdk/src/domain/output_plans/windsurf_output_plan.rs
+++ b/sdk/src/domain/output_plans/windsurf_output_plan.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
 use crate::CliError;
-use crate::domain::output_context::OutputContext;
 use crate::domain::base_output_plans::{BaseOutputFileDeclarationDto, BaseOutputPluginPlanDto};
-use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 use crate::domain::cleanup::{CleanupDeclarationsDto, CleanupTargetDto, CleanupTargetKindDto};
+use crate::domain::output_context::OutputContext;
+use crate::domain::plugin_shared::{Project, RelativePath, Workspace};
 
 const WINDSURF_PLUGIN_NAME: &str = "WindsurfOutputAdaptor";
 const WINDSURF_MEMORY_FILE: &str = ".windsurfrules";

--- a/sdk/src/infra/git_fs.rs
+++ b/sdk/src/infra/git_fs.rs
@@ -101,7 +101,11 @@ mod tests {
 
     let result = resolve_git_info_dir(tmp.path());
     assert!(result.is_some());
-    let result_str = result.as_ref().unwrap().to_string_lossy().replace('\\', "/");
+    let result_str = result
+      .as_ref()
+      .unwrap()
+      .to_string_lossy()
+      .replace('\\', "/");
     // On Windows, absolute paths starting with / get a drive letter prefix
     let result_normalized = result_str
       .strip_prefix("C:")

--- a/sdk/src/infra/logger/core.rs
+++ b/sdk/src/infra/logger/core.rs
@@ -4,7 +4,9 @@ use std::time::{Duration, Instant};
 use serde::Serialize;
 use serde_json::Value;
 
-use super::diagnostic::{DiagnosticInput, invalid_record, record_from_input, validate_diagnostic_input};
+use super::diagnostic::{
+  DiagnosticInput, invalid_record, record_from_input, validate_diagnostic_input,
+};
 use super::sink::buffer_diagnostic;
 
 // ---------------------------------------------------------------------------
@@ -102,7 +104,10 @@ impl SpanGuard {
   fn new(span: Span) -> Self {
     // Emit span enter event immediately
     crate::infra::logger::sink::write_span_enter(&span);
-    Self { span, exited: false }
+    Self {
+      span,
+      exited: false,
+    }
   }
 
   pub fn exit(mut self) {
@@ -204,9 +209,12 @@ impl Logger {
   fn log_diagnostic(&self, level: LogLevel, diagnostic: DiagnosticInput) {
     let record = match validate_diagnostic_input(&diagnostic) {
       Ok(()) => record_from_input(&self.namespace, level.as_str(), diagnostic),
-      Err(errors) => {
-        invalid_record(&self.namespace, level.as_str(), serde_json::to_value(&diagnostic).unwrap_or_default(), &errors)
-      }
+      Err(errors) => invalid_record(
+        &self.namespace,
+        level.as_str(),
+        serde_json::to_value(&diagnostic).unwrap_or_default(),
+        &errors,
+      ),
     };
 
     // Buffer diagnostics even if level is Silent

--- a/sdk/src/infra/logger/diagnostic.rs
+++ b/sdk/src/infra/logger/diagnostic.rs
@@ -50,7 +50,9 @@ pub fn validate_diagnostic_input(input: &DiagnosticInput) -> Result<(), Vec<Stri
     errors.push("rootCause must contain at least one line".to_string());
   }
 
-  if let Some(lines) = &input.exact_fix && lines.is_empty() {
+  if let Some(lines) = &input.exact_fix
+    && lines.is_empty()
+  {
     errors.push("exactFix must contain at least one line when provided".to_string());
   }
 
@@ -60,7 +62,9 @@ pub fn validate_diagnostic_input(input: &DiagnosticInput) -> Result<(), Vec<Stri
     }
     for (index, lines) in fixes.iter().enumerate() {
       if lines.is_empty() {
-        errors.push(format!("possibleFixes[{index}] must contain at least one line"));
+        errors.push(format!(
+          "possibleFixes[{index}] must contain at least one line"
+        ));
       }
     }
   }
@@ -156,11 +160,7 @@ fn append_section(
 use super::formatter::value_to_markdown_lines;
 
 /// Build a diagnostic record from validated input.
-pub fn record_from_input(
-  namespace: &str,
-  level: &str,
-  input: DiagnosticInput,
-) -> DiagnosticRecord {
+pub fn record_from_input(namespace: &str, level: &str, input: DiagnosticInput) -> DiagnosticRecord {
   let mut record = DiagnosticRecord {
     code: input.code.trim().to_string(),
     title: input.title.trim().to_string(),

--- a/sdk/src/infra/logger/formatter.rs
+++ b/sdk/src/infra/logger/formatter.rs
@@ -5,12 +5,8 @@ use super::core::{Event, LogLevel, Span};
 /// Format an event as Markdown.
 pub fn format_event(event: &Event) -> String {
   match event.level {
-    LogLevel::Warn | LogLevel::Error | LogLevel::Fatal => {
-      format_diagnostic_event(event)
-    }
-    _ => {
-      format_message_event(event)
-    }
+    LogLevel::Warn | LogLevel::Error | LogLevel::Fatal => format_diagnostic_event(event),
+    _ => format_message_event(event),
   }
 }
 
@@ -22,7 +18,10 @@ pub fn format_span_enter(span: &Span) -> String {
 /// Format a span exit event with duration.
 pub fn format_span_exit(span: &Span) -> String {
   let duration_ms = span.duration().as_millis();
-  format!("### {} completed\n  - duration: {}ms", span.name, duration_ms)
+  format!(
+    "### {} completed\n  - duration: {}ms",
+    span.name, duration_ms
+  )
 }
 
 fn format_message_event(event: &Event) -> String {
@@ -52,10 +51,11 @@ fn format_message_event(event: &Event) -> String {
 
 fn format_diagnostic_event(event: &Event) -> String {
   // For diagnostic events, the message contains the serialized DiagnosticRecord
-  let record: super::diagnostic::DiagnosticRecord = match serde_json::from_value(event.message.clone()) {
-    Ok(r) => r,
-    Err(_) => return "### Diagnostic error\n  - failed to parse diagnostic record".to_string(),
-  };
+  let record: super::diagnostic::DiagnosticRecord =
+    match serde_json::from_value(event.message.clone()) {
+      Ok(r) => r,
+      Err(_) => return "### Diagnostic error\n  - failed to parse diagnostic record".to_string(),
+    };
 
   let mut lines = vec![format!("### {}", record.title)];
 
@@ -108,7 +108,10 @@ fn format_diagnostic_event(event: &Event) -> String {
   lines.join("\n")
 }
 
-fn extract_message_and_meta(message: &Value, meta: Option<&Value>) -> (Option<String>, Vec<String>) {
+fn extract_message_and_meta(
+  message: &Value,
+  meta: Option<&Value>,
+) -> (Option<String>, Vec<String>) {
   let (msg, mut lines) = match message {
     Value::String(s) => (Some(s.clone()), Vec::new()),
     Value::Object(map) => {
@@ -159,7 +162,12 @@ pub(crate) fn value_to_markdown_lines(value: &Value) -> Vec<String> {
   lines
 }
 
-pub(crate) fn append_markdown_value(lines: &mut Vec<String>, label: Option<&str>, value: &Value, depth: usize) {
+pub(crate) fn append_markdown_value(
+  lines: &mut Vec<String>,
+  label: Option<&str>,
+  value: &Value,
+  depth: usize,
+) {
   let prefix = "  ".repeat(depth);
   let bullet = format!("{prefix}- ");
 

--- a/sdk/src/infra/logger/mod.rs
+++ b/sdk/src/infra/logger/mod.rs
@@ -10,7 +10,9 @@ pub mod diagnostic;
 pub mod formatter;
 pub mod sink;
 
-pub use core::{LogLevel, Logger, Span, SpanGuard, get_global_level, resolve_level, set_global_level};
+pub use core::{
+  LogLevel, Logger, Span, SpanGuard, get_global_level, resolve_level, set_global_level,
+};
 pub use diagnostic::{DiagnosticInput, DiagnosticRecord, validate_diagnostic_input};
 pub use sink::{clear_diagnostics, drain_diagnostics, flush};
 
@@ -232,7 +234,9 @@ mod tests {
   #[test]
   fn test_resolve_level_fallback_to_global() {
     set_global_level(LogLevel::Warn);
-    unsafe { std::env::remove_var("LOG_LEVEL"); }
+    unsafe {
+      std::env::remove_var("LOG_LEVEL");
+    }
     let level = resolve_level(None);
     assert_eq!(level, LogLevel::Warn);
   }

--- a/sdk/src/infra/logger/sink.rs
+++ b/sdk/src/infra/logger/sink.rs
@@ -1,5 +1,5 @@
 use std::io::{self, Write};
-use std::sync::mpsc::{self, Sender, Receiver};
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{LazyLock, Mutex};
 use std::thread;
 
@@ -29,7 +29,10 @@ static DIAGNOSTIC_BUFFER: LazyLock<Mutex<Vec<DiagnosticRecord>>> =
 // ---------------------------------------------------------------------------
 
 pub fn write_event(event: &Event) {
-  let use_stderr = matches!(event.level, LogLevel::Error | LogLevel::Fatal | LogLevel::Warn);
+  let use_stderr = matches!(
+    event.level,
+    LogLevel::Error | LogLevel::Fatal | LogLevel::Warn
+  );
   let output = formatter::format_event(event);
   send_output(use_stderr, output);
 }
@@ -65,7 +68,10 @@ pub fn clear_diagnostics() {
 
 pub fn flush() {
   let (ack_tx, ack_rx) = mpsc::channel();
-  if OUTPUT_SINK.send(OutputCommand::Flush { ack: ack_tx }).is_ok() {
+  if OUTPUT_SINK
+    .send(OutputCommand::Flush { ack: ack_tx })
+    .is_ok()
+  {
     let _ = ack_rx.recv();
   }
 }
@@ -76,7 +82,10 @@ pub fn flush() {
 
 fn send_output(use_stderr: bool, output: String) {
   if OUTPUT_SINK
-    .send(OutputCommand::Write { use_stderr, output: output.clone() })
+    .send(OutputCommand::Write {
+      use_stderr,
+      output: output.clone(),
+    })
     .is_err()
   {
     // Fallback: write directly if sink thread is dead

--- a/sdk/src/repositories/localized_reader.rs
+++ b/sdk/src/repositories/localized_reader.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::path::Path;
 
 use crate::repositories::prompt_artifact::{PromptArtifact, read_prompt_artifact};
@@ -16,17 +15,10 @@ pub fn read_flat_files(
   global_scope_json: Option<&str>,
 ) -> Result<Vec<FlatFileEntry>, crate::CliError> {
   let mut entries: Vec<FlatFileEntry> = Vec::new();
-  let mut seen: HashSet<String> = HashSet::new();
 
   let dir_path = Path::new(dir);
   if dir_path.is_dir() {
-    scan_directory(
-      dir_path,
-      dir_path,
-      &mut seen,
-      &mut entries,
-      global_scope_json,
-    )?;
+    scan_directory(dir_path, dir_path, &mut entries, global_scope_json)?;
   }
 
   Ok(entries)
@@ -35,7 +27,6 @@ pub fn read_flat_files(
 fn scan_directory(
   root: &Path,
   current: &Path,
-  seen: &mut HashSet<String>,
   entries: &mut Vec<FlatFileEntry>,
   global_scope_json: Option<&str>,
 ) -> Result<(), crate::CliError> {
@@ -43,7 +34,7 @@ fn scan_directory(
     let entry = entry.map_err(crate::CliError::IoError)?;
     let path = entry.path();
     if path.is_dir() {
-      scan_directory(root, &path, seen, entries, global_scope_json)?;
+      scan_directory(root, &path, entries, global_scope_json)?;
       continue;
     }
     let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
@@ -113,7 +104,6 @@ fn scan_directory(
         existing.compiled = Some(artifact);
       }
     } else {
-      seen.insert(full_name.clone());
       let mut e = FlatFileEntry {
         name: full_name,
         compiled: None,

--- a/sdk/src/services/clean_service.rs
+++ b/sdk/src/services/clean_service.rs
@@ -16,7 +16,13 @@ use crate::services::common::{
 use crate::{CliError, MemorySyncCommandOptions, MemorySyncCommandResult};
 
 pub fn clean(options: MemorySyncCommandOptions) -> Result<MemorySyncCommandResult, CliError> {
-  let logger = create_logger("clean", options.log_level.as_deref().and_then(|s| crate::infra::logger::LogLevel::from_str_loose(s)));
+  let logger = create_logger(
+    "clean",
+    options
+      .log_level
+      .as_deref()
+      .and_then(|s| crate::infra::logger::LogLevel::from_str_loose(s)),
+  );
   let _span = logger.span("command.clean").enter();
 
   logger.info("Clean started", None);
@@ -31,36 +37,56 @@ pub fn clean(options: MemorySyncCommandOptions) -> Result<MemorySyncCommandResul
   let workspace_warning = build_workspace_mismatch_warning(&cwd, &workspace_dir, &config_result);
   let workspace_dir_str = workspace_dir.to_string_lossy().into_owned();
 
-  logger.info("Config loaded", Some(json!({
-    "workspaceDir": &workspace_dir_str,
-  })));
+  logger.info(
+    "Config loaded",
+    Some(json!({
+      "workspaceDir": &workspace_dir_str,
+    })),
+  );
 
   let global_scope = crate::services::common::build_global_scope(&config_result.config);
-  let enabled_plugins = EnabledPlugins::from_config(config_result.config.plugins.as_ref(), DefaultPluginKind::Clean);
+  let enabled_plugins = EnabledPlugins::from_config(
+    config_result.config.plugins.as_ref(),
+    DefaultPluginKind::Clean,
+  );
 
   let context_span = logger.span("context.collect").enter();
-  let context = collect_context(&workspace_dir_str, global_scope.as_ref(), &enabled_plugins, &logger)?;
+  let context = collect_context(
+    &workspace_dir_str,
+    global_scope.as_ref(),
+    &enabled_plugins,
+    &logger,
+  )?;
   context_span.exit();
 
-  logger.info("Context collected", Some(json!({
-    "globalMemory": context.global_memory.is_some(),
-  })));
+  logger.info(
+    "Context collected",
+    Some(json!({
+      "globalMemory": context.global_memory.is_some(),
+    })),
+  );
 
   let discover_span = logger.span("cleanup.discover").enter();
   let (output_map, cleanup_map) = build_output_map(&context, enabled_plugins, &logger)?;
   let mut snapshot = build_cleanup_snapshot(&workspace_dir_str, &output_map, &cleanup_map)?;
   discover_span.exit();
 
-  logger.info("Cleanup targets discovered", Some(json!({
-    "pluginCount": snapshot.plugin_snapshots.len(),
-    "projectRoots": snapshot.project_roots.len(),
-  })));
+  logger.info(
+    "Cleanup targets discovered",
+    Some(json!({
+      "pluginCount": snapshot.plugin_snapshots.len(),
+      "projectRoots": snapshot.project_roots.len(),
+    })),
+  );
 
   // 根据 cwd 限制清理作用域
   if let Some(scope) = resolve_project_scope(&cwd, &workspace_dir) {
-    logger.info("Project scope resolved", Some(json!({
-      "scope": scope.to_string_lossy().to_string(),
-    })));
+    logger.info(
+      "Project scope resolved",
+      Some(json!({
+        "scope": scope.to_string_lossy().to_string(),
+      })),
+    );
     snapshot = filter_snapshot_by_scope(snapshot, &scope, &workspace_dir);
   }
 
@@ -80,13 +106,16 @@ pub fn clean(options: MemorySyncCommandOptions) -> Result<MemorySyncCommandResul
       })
     }));
 
-    logger.info("Dry run plan", Some(json!({
-      "filesToDelete": plan.files_to_delete.len(),
-      "dirsToDelete": plan.dirs_to_delete.len(),
-      "emptyDirsToDelete": plan.empty_dirs_to_delete.len(),
-      "violations": plan.violations.len(),
-      "conflicts": plan.conflicts.len(),
-    })));
+    logger.info(
+      "Dry run plan",
+      Some(json!({
+        "filesToDelete": plan.files_to_delete.len(),
+        "dirsToDelete": plan.dirs_to_delete.len(),
+        "emptyDirsToDelete": plan.empty_dirs_to_delete.len(),
+        "violations": plan.violations.len(),
+        "conflicts": plan.conflicts.len(),
+      })),
+    );
 
     Ok(MemorySyncCommandResult {
       success: plan.conflicts.is_empty() && plan.violations.is_empty(),
@@ -116,8 +145,8 @@ pub fn clean(options: MemorySyncCommandOptions) -> Result<MemorySyncCommandResul
     })
   } else {
     let execute_span = logger.span("cleanup.execute").enter();
-    let result = crate::policy::cleanup::perform_cleanup(snapshot)
-      .map_err(|e| CliError::ExecutionError(e))?;
+    let result =
+      crate::policy::cleanup::perform_cleanup(snapshot).map_err(|e| CliError::ExecutionError(e))?;
     execute_span.exit();
 
     let blocked = !result.violations.is_empty() || !result.conflicts.is_empty();
@@ -151,14 +180,17 @@ pub fn clean(options: MemorySyncCommandOptions) -> Result<MemorySyncCommandResul
       })
     }));
 
-    logger.info("Clean completed", Some(json!({
-      "success": success,
-      "deletedFiles": result.deleted_files,
-      "deletedDirs": result.deleted_dirs,
-      "conflicts": result.conflicts.len(),
-      "violations": result.violations.len(),
-      "errors": result.errors.len(),
-    })));
+    logger.info(
+      "Clean completed",
+      Some(json!({
+        "success": success,
+        "deletedFiles": result.deleted_files,
+        "deletedDirs": result.deleted_dirs,
+        "conflicts": result.conflicts.len(),
+        "violations": result.violations.len(),
+        "errors": result.errors.len(),
+      })),
+    );
 
     Ok(MemorySyncCommandResult {
       success,
@@ -283,34 +315,87 @@ fn build_output_map(
   }
 
   // Build plugin-specific output maps
-  if let Ok(plan) = crate::domain::output_plans::claude_code_output_plan::build_claude_code_output_plan(context) {
-    cleanup_map.entry("ClaudeCodeCLIOutputAdaptor".to_string()).or_insert_with(CleanupDeclarationsDto::default).delete.extend(plan.cleanup.delete.clone());
+  if let Ok(plan) =
+    crate::domain::output_plans::claude_code_output_plan::build_claude_code_output_plan(context)
+  {
+    cleanup_map
+      .entry("ClaudeCodeCLIOutputAdaptor".to_string())
+      .or_insert_with(CleanupDeclarationsDto::default)
+      .delete
+      .extend(plan.cleanup.delete.clone());
     if enabled_plugins.claude_code {
-      for file in &plan.output_files { output_map.entry("ClaudeCodeCLIOutputAdaptor".to_string()).or_default().push(file.path.clone()); }
+      for file in &plan.output_files {
+        output_map
+          .entry("ClaudeCodeCLIOutputAdaptor".to_string())
+          .or_default()
+          .push(file.path.clone());
+      }
     }
   }
-  if let Ok(plan) = crate::domain::output_plans::codex_output_plan::build_codex_output_plan(context) {
-    cleanup_map.entry("CodexCLIOutputAdaptor".to_string()).or_insert_with(CleanupDeclarationsDto::default).delete.extend(plan.cleanup.delete.clone());
+  if let Ok(plan) = crate::domain::output_plans::codex_output_plan::build_codex_output_plan(context)
+  {
+    cleanup_map
+      .entry("CodexCLIOutputAdaptor".to_string())
+      .or_insert_with(CleanupDeclarationsDto::default)
+      .delete
+      .extend(plan.cleanup.delete.clone());
     if enabled_plugins.codex {
-      for file in &plan.output_files { output_map.entry("CodexCLIOutputAdaptor".to_string()).or_default().push(file.path.clone()); }
+      for file in &plan.output_files {
+        output_map
+          .entry("CodexCLIOutputAdaptor".to_string())
+          .or_default()
+          .push(file.path.clone());
+      }
     }
   }
-  if let Ok(plan) = crate::domain::output_plans::cursor_output_plan::build_cursor_output_plan(context) {
-    cleanup_map.entry("CursorOutputAdaptor".to_string()).or_insert_with(CleanupDeclarationsDto::default).delete.extend(plan.cleanup.delete.clone());
+  if let Ok(plan) =
+    crate::domain::output_plans::cursor_output_plan::build_cursor_output_plan(context)
+  {
+    cleanup_map
+      .entry("CursorOutputAdaptor".to_string())
+      .or_insert_with(CleanupDeclarationsDto::default)
+      .delete
+      .extend(plan.cleanup.delete.clone());
     if enabled_plugins.cursor {
-      for file in &plan.output_files { output_map.entry("CursorOutputAdaptor".to_string()).or_default().push(file.path.clone()); }
+      for file in &plan.output_files {
+        output_map
+          .entry("CursorOutputAdaptor".to_string())
+          .or_default()
+          .push(file.path.clone());
+      }
     }
   }
-  if let Ok(plan) = crate::domain::output_plans::droid_output_plan::build_droid_output_plan(context) {
-    cleanup_map.entry("DroidCLIOutputAdaptor".to_string()).or_insert_with(CleanupDeclarationsDto::default).delete.extend(plan.cleanup.delete.clone());
+  if let Ok(plan) = crate::domain::output_plans::droid_output_plan::build_droid_output_plan(context)
+  {
+    cleanup_map
+      .entry("DroidCLIOutputAdaptor".to_string())
+      .or_insert_with(CleanupDeclarationsDto::default)
+      .delete
+      .extend(plan.cleanup.delete.clone());
     if enabled_plugins.droid {
-      for file in &plan.output_files { output_map.entry("DroidCLIOutputAdaptor".to_string()).or_default().push(file.path.clone()); }
+      for file in &plan.output_files {
+        output_map
+          .entry("DroidCLIOutputAdaptor".to_string())
+          .or_default()
+          .push(file.path.clone());
+      }
     }
   }
-  if let Ok(plan) = crate::domain::output_plans::gemini_output_plan::build_gemini_output_plan(context) {
-    cleanup_map.entry("GeminiCLIOutputAdaptor".to_string()).or_insert_with(CleanupDeclarationsDto::default).delete.extend(plan.cleanup.delete.clone());
+  if let Ok(plan) =
+    crate::domain::output_plans::gemini_output_plan::build_gemini_output_plan(context)
+  {
+    cleanup_map
+      .entry("GeminiCLIOutputAdaptor".to_string())
+      .or_insert_with(CleanupDeclarationsDto::default)
+      .delete
+      .extend(plan.cleanup.delete.clone());
     if enabled_plugins.gemini {
-      for file in &plan.output_files { output_map.entry("GeminiCLIOutputAdaptor".to_string()).or_default().push(file.path.clone()); }
+      for file in &plan.output_files {
+        output_map
+          .entry("GeminiCLIOutputAdaptor".to_string())
+          .or_default()
+          .push(file.path.clone());
+      }
     }
   }
   if let Ok(plan) = crate::domain::output_plans::jetbrains_ai_assistant_codex_output_plan::build_jetbrains_ai_assistant_codex_output_plan(context) {
@@ -320,39 +405,98 @@ fn build_output_map(
     }
   }
   if let Ok(plan) = crate::domain::output_plans::kiro_output_plan::build_kiro_output_plan(context) {
-    cleanup_map.entry("KiroCLIOutputAdaptor".to_string()).or_insert_with(CleanupDeclarationsDto::default).delete.extend(plan.cleanup.delete.clone());
+    cleanup_map
+      .entry("KiroCLIOutputAdaptor".to_string())
+      .or_insert_with(CleanupDeclarationsDto::default)
+      .delete
+      .extend(plan.cleanup.delete.clone());
     if enabled_plugins.kiro {
-      for file in &plan.output_files { output_map.entry("KiroCLIOutputAdaptor".to_string()).or_default().push(file.path.clone()); }
+      for file in &plan.output_files {
+        output_map
+          .entry("KiroCLIOutputAdaptor".to_string())
+          .or_default()
+          .push(file.path.clone());
+      }
     }
   }
-  if let Ok(plan) = crate::domain::output_plans::opencode_output_plan::build_opencode_output_plan(context) {
-    cleanup_map.entry("OpencodeCLIOutputAdaptor".to_string()).or_insert_with(CleanupDeclarationsDto::default).delete.extend(plan.cleanup.delete.clone());
+  if let Ok(plan) =
+    crate::domain::output_plans::opencode_output_plan::build_opencode_output_plan(context)
+  {
+    cleanup_map
+      .entry("OpencodeCLIOutputAdaptor".to_string())
+      .or_insert_with(CleanupDeclarationsDto::default)
+      .delete
+      .extend(plan.cleanup.delete.clone());
     if enabled_plugins.opencode {
-      for file in &plan.output_files { output_map.entry("OpencodeCLIOutputAdaptor".to_string()).or_default().push(file.path.clone()); }
+      for file in &plan.output_files {
+        output_map
+          .entry("OpencodeCLIOutputAdaptor".to_string())
+          .or_default()
+          .push(file.path.clone());
+      }
     }
   }
-  if let Ok(plan) = crate::domain::output_plans::qoder_output_plan::build_qoder_output_plan(context) {
-    cleanup_map.entry("QoderIDEPluginOutputAdaptor".to_string()).or_insert_with(CleanupDeclarationsDto::default).delete.extend(plan.cleanup.delete.clone());
+  if let Ok(plan) = crate::domain::output_plans::qoder_output_plan::build_qoder_output_plan(context)
+  {
+    cleanup_map
+      .entry("QoderIDEPluginOutputAdaptor".to_string())
+      .or_insert_with(CleanupDeclarationsDto::default)
+      .delete
+      .extend(plan.cleanup.delete.clone());
     if enabled_plugins.qoder {
-      for file in &plan.output_files { output_map.entry("QoderIDEPluginOutputAdaptor".to_string()).or_default().push(file.path.clone()); }
+      for file in &plan.output_files {
+        output_map
+          .entry("QoderIDEPluginOutputAdaptor".to_string())
+          .or_default()
+          .push(file.path.clone());
+      }
     }
   }
   if let Ok(plan) = crate::domain::output_plans::trae_output_plan::build_trae_output_plan(context) {
-    cleanup_map.entry("TraeOutputAdaptor".to_string()).or_insert_with(CleanupDeclarationsDto::default).delete.extend(plan.cleanup.delete.clone());
+    cleanup_map
+      .entry("TraeOutputAdaptor".to_string())
+      .or_insert_with(CleanupDeclarationsDto::default)
+      .delete
+      .extend(plan.cleanup.delete.clone());
     if enabled_plugins.trae || enabled_plugins.trae_cn {
-      for file in &plan.output_files { output_map.entry("TraeOutputAdaptor".to_string()).or_default().push(file.path.clone()); }
+      for file in &plan.output_files {
+        output_map
+          .entry("TraeOutputAdaptor".to_string())
+          .or_default()
+          .push(file.path.clone());
+      }
     }
   }
   if let Ok(plan) = crate::domain::output_plans::warp_output_plan::build_warp_output_plan(context) {
-    cleanup_map.entry("WarpIDEOutputAdaptor".to_string()).or_insert_with(CleanupDeclarationsDto::default).delete.extend(plan.cleanup.delete.clone());
+    cleanup_map
+      .entry("WarpIDEOutputAdaptor".to_string())
+      .or_insert_with(CleanupDeclarationsDto::default)
+      .delete
+      .extend(plan.cleanup.delete.clone());
     if enabled_plugins.warp {
-      for file in &plan.output_files { output_map.entry("WarpIDEOutputAdaptor".to_string()).or_default().push(file.path.clone()); }
+      for file in &plan.output_files {
+        output_map
+          .entry("WarpIDEOutputAdaptor".to_string())
+          .or_default()
+          .push(file.path.clone());
+      }
     }
   }
-  if let Ok(plan) = crate::domain::output_plans::windsurf_output_plan::build_windsurf_output_plan(context) {
-    cleanup_map.entry("WindsurfOutputAdaptor".to_string()).or_insert_with(CleanupDeclarationsDto::default).delete.extend(plan.cleanup.delete.clone());
+  if let Ok(plan) =
+    crate::domain::output_plans::windsurf_output_plan::build_windsurf_output_plan(context)
+  {
+    cleanup_map
+      .entry("WindsurfOutputAdaptor".to_string())
+      .or_insert_with(CleanupDeclarationsDto::default)
+      .delete
+      .extend(plan.cleanup.delete.clone());
     if enabled_plugins.windsurf {
-      for file in &plan.output_files { output_map.entry("WindsurfOutputAdaptor".to_string()).or_default().push(file.path.clone()); }
+      for file in &plan.output_files {
+        output_map
+          .entry("WindsurfOutputAdaptor".to_string())
+          .or_default()
+          .push(file.path.clone());
+      }
     }
   }
 
@@ -511,7 +655,10 @@ mod tests {
     result
   }
 
-  fn create_test_config(home_dir: &std::path::Path, workspace_dir: &std::path::Path) -> std::io::Result<()> {
+  fn create_test_config(
+    home_dir: &std::path::Path,
+    workspace_dir: &std::path::Path,
+  ) -> std::io::Result<()> {
     let config_content = json!({
       "workspaceDir": workspace_dir.to_string_lossy()
     });
@@ -874,10 +1021,8 @@ mod tests {
     std::fs::create_dir_all(ws.join("project-b")).unwrap();
 
     let scope = ws.join("project-a");
-    let snapshot = build_cleanup_snapshot(&ws.to_string_lossy(),
-      &HashMap::new(),
-      &HashMap::new(),
-    ).unwrap();
+    let snapshot =
+      build_cleanup_snapshot(&ws.to_string_lossy(), &HashMap::new(), &HashMap::new()).unwrap();
 
     let filtered = filter_snapshot_by_scope(snapshot, &scope, ws);
 

--- a/sdk/src/services/common.rs
+++ b/sdk/src/services/common.rs
@@ -3,10 +3,10 @@ use std::path::{Path, PathBuf};
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
 
+use crate::CliError;
 use crate::context::OutputContext;
 use crate::domain::config::{self, ConfigLoader, PluginsConfig, UserConfigFile};
 use crate::infra::logger::Logger;
-use crate::CliError;
 
 // ---------------------------------------------------------------------------
 // Plugin defaults
@@ -386,7 +386,6 @@ pub fn collect_context(
   enabled_plugins: &EnabledPlugins,
   logger: &Logger,
 ) -> Result<OutputContext, CliError> {
-
   let aindex = {
     let _span = logger.span("collect.aindex_resolvers").enter();
     collect_json::<WorkspaceEnvelope>(

--- a/sdk/src/services/dry_run_service.rs
+++ b/sdk/src/services/dry_run_service.rs
@@ -22,7 +22,13 @@ struct PlannedOutputFile {
 }
 
 pub fn dry_run(options: MemorySyncCommandOptions) -> Result<MemorySyncCommandResult, CliError> {
-  let logger = create_logger("dry_run", options.log_level.as_deref().and_then(|s| crate::infra::logger::LogLevel::from_str_loose(s)));
+  let logger = create_logger(
+    "dry_run",
+    options
+      .log_level
+      .as_deref()
+      .and_then(|s| crate::infra::logger::LogLevel::from_str_loose(s)),
+  );
   let _span = logger.span("command.dry_run").enter();
 
   logger.info("Dry run started", None);
@@ -39,28 +45,45 @@ pub fn dry_run(options: MemorySyncCommandOptions) -> Result<MemorySyncCommandRes
     .collect();
   let workspace_dir_str = workspace_dir.to_string_lossy().into_owned();
 
-  logger.info("Config loaded", Some(json!({
-    "workspaceDir": &workspace_dir_str,
-    "configFound": config_result.found,
-  })));
+  logger.info(
+    "Config loaded",
+    Some(json!({
+      "workspaceDir": &workspace_dir_str,
+      "configFound": config_result.found,
+    })),
+  );
 
   let global_scope = crate::services::common::build_global_scope(&config_result.config);
-  let enabled_plugins = EnabledPlugins::from_config(config_result.config.plugins.as_ref(), DefaultPluginKind::DryRun);
+  let enabled_plugins = EnabledPlugins::from_config(
+    config_result.config.plugins.as_ref(),
+    DefaultPluginKind::DryRun,
+  );
 
-  logger.info("Plugins resolved", Some(json!({
-    "enabled": enabled_plugins.registered_plugins(),
-  })));
+  logger.info(
+    "Plugins resolved",
+    Some(json!({
+      "enabled": enabled_plugins.registered_plugins(),
+    })),
+  );
 
   let context_span = logger.span("context.collect").enter();
-  let context = collect_context(&workspace_dir_str, global_scope.as_ref(), &enabled_plugins, &logger)?;
+  let context = collect_context(
+    &workspace_dir_str,
+    global_scope.as_ref(),
+    &enabled_plugins,
+    &logger,
+  )?;
   context_span.exit();
 
-  logger.info("Context collected", Some(json!({
-    "globalMemory": context.global_memory.is_some(),
-    "commands": context.fast_commands.as_ref().map(|v| v.len()),
-    "skills": context.skills.as_ref().map(|v| v.len()),
-    "rules": context.rules.as_ref().map(|v| v.len()),
-  })));
+  logger.info(
+    "Context collected",
+    Some(json!({
+      "globalMemory": context.global_memory.is_some(),
+      "commands": context.fast_commands.as_ref().map(|v| v.len()),
+      "skills": context.skills.as_ref().map(|v| v.len()),
+      "rules": context.rules.as_ref().map(|v| v.len()),
+    })),
+  );
 
   let output_span = logger.span("output.build").enter();
   let planned_outputs = build_output_files(&context, enabled_plugins)?;
@@ -79,10 +102,13 @@ pub fn dry_run(options: MemorySyncCommandOptions) -> Result<MemorySyncCommandRes
     files_affected += 1;
   }
 
-  logger.info("Dry run completed", Some(json!({
-    "filesWouldCreate": files_affected,
-    "dirsWouldCreate": dirs_affected,
-  })));
+  logger.info(
+    "Dry run completed",
+    Some(json!({
+      "filesWouldCreate": files_affected,
+      "dirsWouldCreate": dirs_affected,
+    })),
+  );
 
   let message = if options.dry_run.unwrap_or(false) {
     Some(format!(
@@ -116,7 +142,8 @@ fn build_output_files(
   push_base_plans(&mut outputs, &base_plans, enabled_plugins);
 
   if enabled_plugins.claude_code {
-    let plan = crate::domain::output_plans::claude_code_output_plan::build_claude_code_output_plan(context)?;
+    let plan =
+      crate::domain::output_plans::claude_code_output_plan::build_claude_code_output_plan(context)?;
     push_base_output_files(&mut outputs, &plan.output_files);
   }
   if enabled_plugins.codex {
@@ -144,7 +171,8 @@ fn build_output_files(
     push_base_output_files(&mut outputs, &plan.output_files);
   }
   if enabled_plugins.opencode {
-    let plan = crate::domain::output_plans::opencode_output_plan::build_opencode_output_plan(context)?;
+    let plan =
+      crate::domain::output_plans::opencode_output_plan::build_opencode_output_plan(context)?;
     push_base_output_files(&mut outputs, &plan.output_files);
   }
   if enabled_plugins.qoder {
@@ -160,7 +188,8 @@ fn build_output_files(
     push_base_output_files(&mut outputs, &plan.output_files);
   }
   if enabled_plugins.windsurf {
-    let plan = crate::domain::output_plans::windsurf_output_plan::build_windsurf_output_plan(context)?;
+    let plan =
+      crate::domain::output_plans::windsurf_output_plan::build_windsurf_output_plan(context)?;
     push_base_output_files(&mut outputs, &plan.output_files);
   }
 
@@ -241,7 +270,10 @@ mod tests {
     result
   }
 
-  fn create_test_config(home_dir: &std::path::Path, workspace_dir: &std::path::Path) -> std::io::Result<()> {
+  fn create_test_config(
+    home_dir: &std::path::Path,
+    workspace_dir: &std::path::Path,
+  ) -> std::io::Result<()> {
     let config_content = json!({
       "workspaceDir": workspace_dir.to_string_lossy()
     });

--- a/sdk/src/services/install_service.rs
+++ b/sdk/src/services/install_service.rs
@@ -27,12 +27,21 @@ struct PlannedOutputFile {
 pub(crate) fn install(
   options: MemorySyncCommandOptions,
 ) -> Result<MemorySyncCommandResult, CliError> {
-  let logger = create_logger("install", options.log_level.as_deref().and_then(|s| crate::infra::logger::LogLevel::from_str_loose(s)));
+  let logger = create_logger(
+    "install",
+    options
+      .log_level
+      .as_deref()
+      .and_then(|s| crate::infra::logger::LogLevel::from_str_loose(s)),
+  );
   let _span = logger.span("command.install").enter();
 
-  logger.info("Install started", Some(json!({
-    "cwd": options.cwd.as_ref(),
-  })));
+  logger.info(
+    "Install started",
+    Some(json!({
+      "cwd": options.cwd.as_ref(),
+    })),
+  );
 
   let cwd = resolve_cwd(options.cwd.as_deref())?;
 
@@ -46,37 +55,57 @@ pub(crate) fn install(
     .collect::<Vec<_>>();
   let workspace_dir_str = workspace_dir.to_string_lossy().into_owned();
 
-  logger.info("Config loaded", Some(json!({
-    "workspaceDir": &workspace_dir_str,
-    "configFound": config_result.found,
-    "configSources": config_result.sources,
-  })));
+  logger.info(
+    "Config loaded",
+    Some(json!({
+      "workspaceDir": &workspace_dir_str,
+      "configFound": config_result.found,
+      "configSources": config_result.sources,
+    })),
+  );
 
   let global_scope = crate::services::common::build_global_scope(&config_result.config);
-  let enabled_plugins = EnabledPlugins::from_config(config_result.config.plugins.as_ref(), DefaultPluginKind::Install);
+  let enabled_plugins = EnabledPlugins::from_config(
+    config_result.config.plugins.as_ref(),
+    DefaultPluginKind::Install,
+  );
 
-  logger.info("Plugins resolved", Some(json!({
-    "enabled": enabled_plugins.registered_plugins(),
-  })));
+  logger.info(
+    "Plugins resolved",
+    Some(json!({
+      "enabled": enabled_plugins.registered_plugins(),
+    })),
+  );
 
   let context_span = logger.span("context.collect").enter();
-  let context = collect_context(&workspace_dir_str, global_scope.as_ref(), &enabled_plugins, &logger)?;
+  let context = collect_context(
+    &workspace_dir_str,
+    global_scope.as_ref(),
+    &enabled_plugins,
+    &logger,
+  )?;
   context_span.exit();
 
-  logger.info("Context collected", Some(json!({
-    "globalMemory": context.global_memory.is_some(),
-    "commands": context.fast_commands.as_ref().map(|v| v.len()),
-    "skills": context.skills.as_ref().map(|v| v.len()),
-    "rules": context.rules.as_ref().map(|v| v.len()),
-  })));
+  logger.info(
+    "Context collected",
+    Some(json!({
+      "globalMemory": context.global_memory.is_some(),
+      "commands": context.fast_commands.as_ref().map(|v| v.len()),
+      "skills": context.skills.as_ref().map(|v| v.len()),
+      "rules": context.rules.as_ref().map(|v| v.len()),
+    })),
+  );
 
   let output_span = logger.span("output.build").enter();
   let planned_outputs = build_output_files(&context, enabled_plugins, &logger)?;
   output_span.exit();
 
-  logger.info("Output files built", Some(json!({
-    "filesPlanned": planned_outputs.len(),
-  })));
+  logger.info(
+    "Output files built",
+    Some(json!({
+      "filesPlanned": planned_outputs.len(),
+    })),
+  );
 
   let write_span = logger.span("files.write").enter();
   let execution = write_output_files(&planned_outputs, &logger)?;
@@ -84,13 +113,16 @@ pub(crate) fn install(
 
   warnings.extend(execution.warnings);
 
-  logger.info("Install completed", Some(json!({
-    "success": execution.errors.is_empty(),
-    "filesAffected": execution.files_affected,
-    "dirsAffected": execution.dirs_affected,
-    "warnings": warnings.len(),
-    "errors": execution.errors.len(),
-  })));
+  logger.info(
+    "Install completed",
+    Some(json!({
+      "success": execution.errors.is_empty(),
+      "filesAffected": execution.files_affected,
+      "dirsAffected": execution.dirs_affected,
+      "warnings": warnings.len(),
+      "errors": execution.errors.len(),
+    })),
+  );
 
   Ok(MemorySyncCommandResult {
     success: execution.errors.is_empty(),
@@ -125,7 +157,8 @@ fn build_output_files(
 
   if enabled_plugins.claude_code {
     let plugin_span = logger.span("output.claude_code").enter();
-    let plan = crate::domain::output_plans::claude_code_output_plan::build_claude_code_output_plan(context)?;
+    let plan =
+      crate::domain::output_plans::claude_code_output_plan::build_claude_code_output_plan(context)?;
     push_base_output_files(&mut outputs, &plan.output_files);
     plugin_span.exit();
   }
@@ -167,7 +200,8 @@ fn build_output_files(
   }
   if enabled_plugins.opencode {
     let plugin_span = logger.span("output.opencode").enter();
-    let plan = crate::domain::output_plans::opencode_output_plan::build_opencode_output_plan(context)?;
+    let plan =
+      crate::domain::output_plans::opencode_output_plan::build_opencode_output_plan(context)?;
     push_base_output_files(&mut outputs, &plan.output_files);
     plugin_span.exit();
   }
@@ -191,7 +225,8 @@ fn build_output_files(
   }
   if enabled_plugins.windsurf {
     let plugin_span = logger.span("output.windsurf").enter();
-    let plan = crate::domain::output_plans::windsurf_output_plan::build_windsurf_output_plan(context)?;
+    let plan =
+      crate::domain::output_plans::windsurf_output_plan::build_windsurf_output_plan(context)?;
     push_base_output_files(&mut outputs, &plan.output_files);
     plugin_span.exit();
   }
@@ -288,7 +323,10 @@ fn write_output_files(
 
     let existing = fs::read(path).ok();
     if existing.as_deref() == Some(bytes.as_slice()) {
-      logger.debug(format!("file.skipped: {}", file.path), Some(json!({ "reason": "unchanged" })));
+      logger.debug(
+        format!("file.skipped: {}", file.path),
+        Some(json!({ "reason": "unchanged" })),
+      );
       continue;
     }
 

--- a/sdk/src/services/prompt_service.rs
+++ b/sdk/src/services/prompt_service.rs
@@ -1092,7 +1092,10 @@ pub fn get_prompt(
   let def = build_prompt_definition_from_id(prompt_id, &env)?;
   let result = hydrate_prompt(&def, true);
 
-  logger.info(format!("Get prompt: {}", prompt_id), Some(serde_json::json!({ "found": result.is_some() })));
+  logger.info(
+    format!("Get prompt: {}", prompt_id),
+    Some(serde_json::json!({ "found": result.is_some() })),
+  );
   Ok(result)
 }
 
@@ -1113,7 +1116,10 @@ pub fn upsert_prompt_source(input: &UpsertPromptSourceInput) -> Result<PromptDet
   let result = hydrate_prompt(&definition, true)
     .ok_or_else(|| format!("Failed to load prompt after write: {}", input.prompt_id))?;
 
-  logger.info(format!("Upserted prompt: {}", input.prompt_id), Some(serde_json::json!({ "locale": format!("{:?}", locale) })));
+  logger.info(
+    format!("Upserted prompt: {}", input.prompt_id),
+    Some(serde_json::json!({ "locale": format!("{:?}", locale) })),
+  );
   Ok(result)
 }
 


### PR DESCRIPTION
Closes #190.

`read_flat_files` allocated a `HashSet<String>` and threaded it as `&mut seen` through `scan_directory` recursion just to call `seen.insert(full_name.clone())` once per new entry. The set was never read for dedup — `entries.iter_mut().find(|e| e.name == full_name)` is the actual existence check on the line above. (#191 tracks the O(n²) → HashMap follow-up; this PR is just the dead write.)

Removing the parameter:

- Deletes a per-call `String::clone` (set insertion took ownership of a clone of the name we already used to construct the entry).
- Drops the `HashSet` allocation on every call to `read_flat_files`.
- Removes the `use std::collections::HashSet` import.
- Simplifies `scan_directory`'s signature (4 args → 3).

## Test plan

- [x] `cargo build --manifest-path sdk/Cargo.toml` — clean
- [x] `cargo test --manifest-path sdk/Cargo.toml --lib repositories` — 45/45 repository tests pass
- [x] `cargo clippy --manifest-path sdk/Cargo.toml --lib` — no new warnings on `localized_reader.rs`