### PR TITLE
fix: add missing logger initialization in mcp main

### DIFF
--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -394,6 +394,7 @@ fn main() -> ExitCode {
 
   match resolve_command(&cli) {
     ResolvedCommand::Serve => {
+      let logger = tnmsd::infra::logger::create_logger("mcp.server", None);
       let _span = logger.span("server.serve").enter();
       logger.info(
         "MCP server started",


### PR DESCRIPTION
mcp/src/main.rs 的 main() 函数中使用了 logger 变量但未初始化，导致 macOS aarch64 目标编译失败。

修复：在  分支中添加  调用。