### PR TITLE
fix(ci): align pnpm version for release

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -7,9 +7,9 @@ inputs:
     required: false
     default: "25.6.1"
   pnpm-version:
-    description: pnpm version
+    description: pnpm version (must match package.json packageManager)
     required: false
-    default: "10.33.0"
+    default: "11.18.0"
   registry-url:
     description: Optional npm registry URL to configure for npm publish/auth steps
     required: false


### PR DESCRIPTION
## Summary
- CI composite action 默认 pnpm 从 10.33.0 对齐到 package.json 的 11.18.0
- 修复 Release/CI 中 `Multiple versions of pnpm specified` 导致的失败，以便重新发布 v2026.10801.0

## Test plan
- [ ] Release validate-version 通过
- [ ] 其余 Release jobs 正常推进


Made with [Cursor](https://cursor.com)