### PR TITLE
fix(gui): monaco-editor 0.56 worker import paths

### DIFF
--- a/gui/src/components/JsonEditor.tsx
+++ b/gui/src/components/JsonEditor.tsx
@@ -2,8 +2,8 @@ import type { FC } from 'react'
 
 import Editor, { type OnMount, loader } from '@monaco-editor/react'
 import * as monaco from 'monaco-editor'
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
-import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker'
+import editorWorker from 'monaco-editor/editor/editor.worker?worker'
+import jsonWorker from 'monaco-editor/language/json/json.worker?worker'
 import { useCallback, useRef } from 'react'
 
 import { useFont } from '@/hooks/useFont'

--- a/gui/src/pages/FilesPage.tsx
+++ b/gui/src/pages/FilesPage.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { OnMount } from '@monaco-editor/react'
 import Editor, { loader } from '@monaco-editor/react'
 import * as monaco from 'monaco-editor'
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
+import editorWorker from 'monaco-editor/editor/editor.worker?worker'
 
 import { ChevronDown, ChevronRight, RefreshCw, Save } from 'lucide-react'
 

--- a/gui/vitest.setup.ts
+++ b/gui/vitest.setup.ts
@@ -18,6 +18,10 @@ vi.mock('@monaco-editor/react', () => ({
   },
 }))
 
-vi.mock('monaco-editor/esm/vs/editor/editor.worker?worker', () => ({
+vi.mock('monaco-editor/editor/editor.worker?worker', () => ({
+  default: class MockWorker {},
+}))
+
+vi.mock('monaco-editor/language/json/json.worker?worker', () => ({
   default: class MockWorker {},
 }))


### PR DESCRIPTION
## Summary
- 修复 monaco-editor 0.56 exports 变更导致的 `?worker` 解析失败
- 解除 Release 中三平台 GUI 构建阻塞

## Test plan
- [x] 本地 `pnpm exec vite build` 通过
- [ ] Release `build-gui` 三平台通过


Made with [Cursor](https://cursor.com)