### PR TITLE
fix(obsidian): align TNMSOP identity

### DIFF
--- a/.githooks/sync-versions.test.ts
+++ b/.githooks/sync-versions.test.ts
@@ -57,13 +57,13 @@ function createFixtureRepo(): string {
     private: true
   })
   writeJson(join(rootDir, 'obsidian-plugin', 'package.json'), {
-    name: 'tnmso',
+    name: 'tnmsop',
     version: initialVersion,
     private: true
   })
   const manifest = {
-    id: 'tnmso',
-    name: 'TNMSO Preview',
+    id: 'tnmsop',
+    name: 'TNMSOP',
     version: initialVersion,
     minAppVersion: '1.0.0',
     isDesktopOnly: false
@@ -149,13 +149,13 @@ function createFixtureRepo(): string {
 
 function preparePluginRelease(rootDir: string, nextVersion: string): void {
   writeJson(join(rootDir, 'obsidian-plugin', 'package.json'), {
-    name: 'tnmso',
+    name: 'tnmsop',
     version: nextVersion,
     private: true
   })
   writeJson(join(rootDir, 'obsidian-plugin', 'manifest.json'), {
-    id: 'tnmso',
-    name: 'TNMSO Preview',
+    id: 'tnmsop',
+    name: 'TNMSOP',
     version: nextVersion,
     minAppVersion: '1.0.0',
     isDesktopOnly: false
@@ -302,7 +302,7 @@ describe('sync-versions hook', () => {
     expectSharedVersionSurfaces(rootDir, nextVersion)
   })
 
-  it('requires TNMSO to be released before the system version advances', () => {
+  it('requires TNMSOP to be released before the system version advances', () => {
     const rootDir = createFixtureRepo()
     tempDirs.push(rootDir)
 
@@ -314,7 +314,7 @@ describe('sync-versions hook', () => {
     })
     runGit(rootDir, ['add', 'doc/package.json'])
 
-    expect(() => runSyncVersions({rootDir})).toThrowError(/release TNMSO first/)
+    expect(() => runSyncVersions({rootDir})).toThrowError(/release TNMSOP first/)
   })
 
   it('fails when staged package.json files propose conflicting versions', () => {

--- a/.githooks/sync-versions.ts
+++ b/.githooks/sync-versions.ts
@@ -79,16 +79,16 @@ function syncObsidianReleaseMetadata(
   const minAppVersion = manifest.minAppVersion
   const pluginVersion = manifest.version
 
-  if (manifest.id !== 'tnmso' || typeof minAppVersion !== 'string' || minAppVersion.trim() === '') {
-    throw new Error('TNMSO manifest must define id=tnmso and a non-empty minAppVersion')
+  if (manifest.id !== 'tnmsop' || typeof minAppVersion !== 'string' || minAppVersion.trim() === '') {
+    throw new Error('TNMSOP manifest must define id=tnmsop and a non-empty minAppVersion')
   }
   if (pluginVersion !== targetVersion) {
-    throw new Error(`TNMSO submodule has version ${String(pluginVersion)}, expected ${targetVersion}; release TNMSO first`)
+    throw new Error(`TNMSOP submodule has version ${String(pluginVersion)}, expected ${targetVersion}; release TNMSOP first`)
   }
 
   const versions = readJsonFile(pluginVersionsPath)
   if (versions[targetVersion] !== minAppVersion) {
-    throw new Error(`TNMSO versions.json must map ${targetVersion} to ${minAppVersion}`)
+    throw new Error(`TNMSOP versions.json must map ${targetVersion} to ${minAppVersion}`)
   }
 
   writeJsonFileIfChanged(rootManifestPath, manifest, changedPaths)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -502,7 +502,7 @@ jobs:
 
           cli_archive_count=$(find artifacts/cli -type f \( -name '*.tar.gz' -o -name '*.zip' \) | wc -l | tr -d ' ')
           mcp_archive_count=$(find artifacts/mcp -type f \( -name '*.tar.gz' -o -name '*.zip' \) | wc -l | tr -d ' ')
-          obsidian_archive_count=$(find artifacts/obsidian -maxdepth 1 -type f -name 'tnmso-${{ needs.validate-version.outputs.version }}.zip' | wc -l | tr -d ' ')
+          obsidian_archive_count=$(find artifacts/obsidian -maxdepth 1 -type f -name 'tnmsop-${{ needs.validate-version.outputs.version }}.zip' | wc -l | tr -d ' ')
 
           if [[ "$cli_archive_count" -ne 5 ]]; then
             echo "::error::Expected 5 CLI archives, found ${cli_archive_count}."
@@ -530,6 +530,6 @@ jobs:
             artifacts/cli/**/*.zip
             artifacts/mcp/**/*.tar.gz
             artifacts/mcp/**/*.zip
-            artifacts/obsidian/tnmso-*.zip
+            artifacts/obsidian/tnmsop-*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "obsidian-plugin"]
 	path = obsidian-plugin
-	url = https://github.com/TrueNine/tnmso.git
+	url = https://github.com/TrueNine/tnmsop.git

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ MCP server:
 npm install -g @truenine/memory-sync-mcp
 ```
 
-### TNMSO Preview for Obsidian
+### TNMSOP for Obsidian
 
-TNMSO Preview is maintained in the [`obsidian-plugin/`](obsidian-plugin/README.md) submodule. Install it from the Obsidian community directory or download `main.js`, `manifest.json`, and `styles.css` from the matching [TNMSO Preview Release](https://github.com/TrueNine/tnmso/releases). BRAT users should install `TrueNine/tnmso`.
+TNMSOP is maintained in the [`obsidian-plugin/`](obsidian-plugin/README.md) submodule. Install it from the Obsidian community directory or download `main.js`, `manifest.json`, and `styles.css` from the matching [TNMSOP Release](https://github.com/TrueNine/tnmsop/releases). BRAT users should install `TrueNine/tnmsop`.
 
-TNMSO Preview shares the memory-sync CalVer version. The plugin is released first with the exact plain `<version>` tag, then memory-sync pins that release through the submodule and publishes its `v<version>` system release.
+TNMSOP shares the memory-sync CalVer version. The plugin is released first with the exact plain `<version>` tag, then memory-sync pins that release through the submodule and publishes its `v<version>` system release.
 
 ## Supported Tools
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "id": "tnmso",
-  "name": "TNMSO Preview",
+  "id": "tnmsop",
+  "name": "TNMSOP",
   "version": "2026.10805.0",
   "minAppVersion": "1.13.4",
   "description": "Preview prompt-focused MDX files safely as Markdown.",

--- a/scripts/shared/check-version-surfaces.ts
+++ b/scripts/shared/check-version-surfaces.ts
@@ -69,12 +69,12 @@ function checkObsidianReleaseMetadata(): void {
   const rootVersions = readJson('versions.json')
   const minAppVersion = pluginManifest.minAppVersion
 
-  ensure(pluginManifest.id === 'tnmso', 'obsidian-plugin/manifest.json must use id=tnmso')
+  ensure(pluginManifest.id === 'tnmsop', 'obsidian-plugin/manifest.json must use id=tnmsop')
   ensure(pluginManifest.version === expectedVersion, `obsidian-plugin/manifest.json expected version ${expectedVersion}`)
-  ensure(typeof minAppVersion === 'string' && minAppVersion !== '', 'TNMSO minAppVersion is required')
-  ensure(JSON.stringify(rootManifest) === JSON.stringify(pluginManifest), 'Root manifest.json must mirror the TNMSO manifest')
+  ensure(typeof minAppVersion === 'string' && minAppVersion !== '', 'TNMSOP minAppVersion is required')
+  ensure(JSON.stringify(rootManifest) === JSON.stringify(pluginManifest), 'Root manifest.json must mirror the TNMSOP manifest')
   ensure(pluginVersions[expectedVersion] === minAppVersion, `obsidian-plugin/versions.json must map ${expectedVersion} to ${String(minAppVersion)}`)
-  ensure(JSON.stringify(rootVersions) === JSON.stringify(pluginVersions), 'Root versions.json must mirror TNMSO versions.json')
+  ensure(JSON.stringify(rootVersions) === JSON.stringify(pluginVersions), 'Root versions.json must mirror TNMSOP versions.json')
 }
 
 function checkWorkspaceCargoVersion(relativePath: string, sectionName: string, key = 'version'): void {


### PR DESCRIPTION
## Summary

- align the community plugin ID and display name with `tnmsop` / `TNMSOP`
- update the submodule to the canonical `TrueNine/tnmsop` repository and rebuilt release commit
- mirror the corrected manifest and package archive name across memory-sync release checks

## Verification

- version sync tests: 5 passed
- TNMSOP tests: 17 passed
- TNMSOP typecheck, lint, build, package, and dist verification passed
- version surfaces validated for 2026.10805.0
- actionlint passed